### PR TITLE
Http arguments (query string) pull

### DIFF
--- a/src/httpServer.cpp
+++ b/src/httpServer.cpp
@@ -222,7 +222,6 @@ bool HttpServerConnection::handleLine(string line)
             return false;
         request.method = parts[0];
         parseUri(parts[1]);
-        //request.path = parts[1];
         status = HEADERS;
         }break;
     case HEADERS:

--- a/src/httpServer.cpp
+++ b/src/httpServer.cpp
@@ -190,14 +190,14 @@ void HttpServerConnection::parseUri(const string & sSrc)
             std::size_t found = param.find('=');
             if (found==std::string::npos)
             {
-                request.parameters[param] = sFALSE;
+                request.parameters[param] = "";
                 LOG(DEBUG) << "HTTP Parameter: " << param;
             }
             else
             {
                 if (param.endswith('='))
                 {
-                    request.parameters[param.substr(0, param.length()-1)] = sFALSE;
+                    request.parameters[param.substr(0, param.length()-1)] = "";
                     LOG(DEBUG) << "HTTP Parameter: " << param.substr(0, param.length()-1);
                 }
                 else

--- a/src/httpServer.h
+++ b/src/httpServer.h
@@ -6,7 +6,6 @@
 #include "stringImproved.h"
 
 #define sFALSE  "FALSE"
-#define sOBJECT "OBJECT"
 
 class HttpRequest : public sf::NonCopyable
 {

--- a/src/httpServer.h
+++ b/src/httpServer.h
@@ -5,8 +5,6 @@
 #include "Updatable.h"
 #include "stringImproved.h"
 
-#define sFALSE  "FALSE"
-
 class HttpRequest : public sf::NonCopyable
 {
 public:

--- a/src/httpServer.h
+++ b/src/httpServer.h
@@ -5,6 +5,9 @@
 #include "Updatable.h"
 #include "stringImproved.h"
 
+#define sFALSE  "FALSE"
+#define sOBJECT "OBJECT"
+
 class HttpRequest : public sf::NonCopyable
 {
 public:
@@ -12,6 +15,7 @@ public:
     string path;
     string post_data;
     std::map<string, string> headers;
+    std::map<string, string> parameters;
 };
 
 class HttpServer;
@@ -21,7 +25,7 @@ class HttpRequestHandler : public sf::NonCopyable
 public:
     HttpRequestHandler() {}
     virtual ~HttpRequestHandler() {}
-    
+
     virtual bool handleRequest(HttpRequest& request, HttpServerConnection* connection) = 0;
 };
 
@@ -30,7 +34,7 @@ class HttpRequestFileHandler : public HttpRequestHandler
     string base_path;
 public:
     HttpRequestFileHandler(string base_path) : base_path(base_path) {}
-    
+
     virtual bool handleRequest(HttpRequest& request, HttpServerConnection* connection);
 };
 
@@ -46,22 +50,23 @@ private:
     const static size_t recvBufferSize = 2048;
     char recvBuffer[recvBufferSize];
     size_t recvBufferCount;
-    
+    const static char HEX2DEC[256];
     HttpRequest request;
     HttpServer* server;
     int reply_code;
     bool headers_send;
 public:
     sf::TcpSocket socket;
-    
+
     HttpServerConnection(HttpServer* server);
     bool read();
-
     void sendData(const char* data, size_t data_length);
     void sendString(string data) { sendData(data.c_str(), data.length()); }
-private:    
+private:
     bool handleLine(string line);
-    
+
+    string UriDecode(const string & sSrc);
+    void parseUri(const string & sSrc);
     void handleRequest();
     void sendHeaders();
 };
@@ -77,11 +82,11 @@ private:
 public:
     HttpServer(int portNr = 80);
     ~HttpServer();
-    
+
     void addHandler(HttpRequestHandler* handler) { handlers.push_back(handler); }
-    
+
     virtual void update(float delta);
-    
+
     friend class HttpServerConnection;
 };
 


### PR DESCRIPTION
I've added support for parsing of query strings, and decoding if percent-encoded URLs. 
Found parameters are stored in request.parameters.

This is part of an effort to get EmptyEpsilon working with openHAB (http://www.openhab.org/), which does not support custom headers e.g. post-data in its HTTP-connector. 
You can expect another pull-request soon with getters and setters using these query-strings.

You might want to take a look at my memory management, since I'm not sure whether I should explicitly delete variables once I'm done with them inside my functions...