### PR TITLE
retab.  fix unknown keystroke underflow

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -178,11 +178,20 @@ void Engine::handleEvent(sf::Event& event)
 #endif
     if (event.type == sf::Event::KeyPressed)
     {
+		if (event.key.code != sf::Keyboard::Unknown)
         InputHandler::keyboard_button_down[event.key.code] = true;
+#ifdef DEBUG
+		else printf("Unknown key code pressed");
+#endif
         last_key_press = event.key.code;
     }
-    if (event.type == sf::Event::KeyReleased)
+	if (event.type == sf::Event::KeyReleased) {
+		if (event.key.code != sf::Keyboard::Unknown)
         InputHandler::keyboard_button_down[event.key.code] = false;
+#ifdef DEBUG
+		else printf("Unknown key code released");
+#endif
+	}
     if (event.type == sf::Event::TextEntered && event.text.unicode > 31 && event.text.unicode < 128)
     {
         if (last_key_press != sf::Keyboard::Unknown)


### PR DESCRIPTION
I don't know how, but sf input event returned Invalid for a key down event.  This caused a buffer underflow on keyboard_button_down.  Guard against that.

Might want to check upper range, too, in case sf sends a too-large value (yeah, it's an enum, but it's really just an int after all.