### PR TITLE
Port to Visual Studio 2015

### DIFF
--- a/src/collisionable.cpp
+++ b/src/collisionable.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <utility>
+#include <stddef.h>
 #include "collisionable.h"
 #include "Renderable.h"
 #include "vectorUtils.h"

--- a/src/collisionable.cpp
+++ b/src/collisionable.cpp
@@ -27,15 +27,15 @@ class QueryCallback : public b2QueryCallback
 public:
     PVector<Collisionable> list;
 
-	/// Called for each fixture found in the query AABB.
-	/// @return false to terminate the query.
-	virtual bool ReportFixture(b2Fixture* fixture)
-	{
+        /// Called for each fixture found in the query AABB.
+        /// @return false to terminate the query.
+        virtual bool ReportFixture(b2Fixture* fixture)
+        {
         P<Collisionable> ptr = (Collisionable*)fixture->GetBody()->GetUserData();
         if (ptr)
             list.push_back(ptr);
         return true;
-	}
+        }
 };
 
 PVector<Collisionable> CollisionManager::queryArea(sf::Vector2f lowerBound, sf::Vector2f upperBound)

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -178,11 +178,20 @@ void Engine::handleEvent(sf::Event& event)
 #endif
     if (event.type == sf::Event::KeyPressed)
     {
+		if (event.key.code != sf::Keyboard::Unknown)
         InputHandler::keyboard_button_down[event.key.code] = true;
+#ifdef DEBUG
+		else printf("Unknown key code pressed");
+#endif
         last_key_press = event.key.code;
     }
-    if (event.type == sf::Event::KeyReleased)
+	if (event.type == sf::Event::KeyReleased) {
+		if (event.key.code != sf::Keyboard::Unknown)
         InputHandler::keyboard_button_down[event.key.code] = false;
+#ifdef DEBUG
+		else printf("Unknown key code released");
+#endif
+	}
     if (event.type == sf::Event::TextEntered && event.text.unicode > 31 && event.text.unicode < 128)
     {
         if (last_key_press != sf::Keyboard::Unknown)

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -178,20 +178,20 @@ void Engine::handleEvent(sf::Event& event)
 #endif
     if (event.type == sf::Event::KeyPressed)
     {
-		if (event.key.code != sf::Keyboard::Unknown)
-        InputHandler::keyboard_button_down[event.key.code] = true;
+        if (event.key.code != sf::Keyboard::Unknown)
+            InputHandler::keyboard_button_down[event.key.code] = true;
 #ifdef DEBUG
-		else printf("Unknown key code pressed");
+        else printf("Unknown key code pressed");
 #endif
         last_key_press = event.key.code;
     }
-	if (event.type == sf::Event::KeyReleased) {
-		if (event.key.code != sf::Keyboard::Unknown)
-        InputHandler::keyboard_button_down[event.key.code] = false;
+    if (event.type == sf::Event::KeyReleased) {
+        if (event.key.code != sf::Keyboard::Unknown)
+            InputHandler::keyboard_button_down[event.key.code] = false;
 #ifdef DEBUG
-		else printf("Unknown key code released");
+        else printf("Unknown key code released");
 #endif
-	}
+    }
     if (event.type == sf::Event::TextEntered && event.text.unicode > 31 && event.text.unicode < 128)
     {
         if (last_key_press != sf::Keyboard::Unknown)

--- a/src/logging.h
+++ b/src/logging.h
@@ -32,13 +32,14 @@ public:
 
 const Logging& operator<<(const Logging& log, const char* str);
 inline const Logging& operator<<(const Logging& log, const std::string& s) { return log << (s.c_str()); }
-inline const Logging& operator<<(const Logging& log, const int i) { return log << string(i).c_str(); }
-inline const Logging& operator<<(const Logging& log, const unsigned int i) { return log << string(i).c_str(); }
-inline const Logging& operator<<(const Logging& log, const long i) { return log << string(int(i)).c_str(); }
-inline const Logging& operator<<(const Logging& log, const unsigned long i) { return log << string(int(i)).c_str(); }
-inline const Logging& operator<<(const Logging& log, const float f) { return log << string(f).c_str(); }
+// inline const Logging& operator<<(const Logging& log, const int i) { return log << string(i).c_str(); }
+// inline const Logging& operator<<(const Logging& log, const unsigned int i) { return log << string(i).c_str(); }
+// inline const Logging& operator<<(const Logging& log, const long i) { return log << string(int(i)).c_str(); }
+// inline const Logging& operator<<(const Logging& log, const unsigned long i) { return log << string(int(i)).c_str(); }
+// inline const Logging& operator<<(const Logging& log, const float f) { return log << string(f).c_str(); }
 inline const Logging& operator<<(const Logging& log, const double f) { return log << string(f, 2).c_str(); }
 template<typename T> inline const Logging& operator<<(const Logging& log, const sf::Vector2<T> v) { return log << v.x << "," << v.y; }
 template<typename T> inline const Logging& operator<<(const Logging& log, const sf::Rect<T> v) { return log << v.left << "," << v.top << ":" << v.width << "x" << v.height; }
+template<typename T> inline const Logging& operator<<(const Logging& log, const T v) { return log << string(v).c_str(); }
 
 #endif//LOGGING_H

--- a/src/multiplayer.cpp
+++ b/src/multiplayer.cpp
@@ -46,22 +46,7 @@ MultiplayerObject::~MultiplayerObject()
             memberReplicationInfo[n].cleanupFunction(&memberReplicationInfo[n].prev_data);
 }
 
-template <> bool multiplayerReplicationFunctions<string>::isChanged(void* data, void* prev_data_ptr)
-{
-    string* ptr = (string*)data;
-    int64_t* hash_ptr = (int64_t*)prev_data_ptr;
 
-    int64_t hash = 5381;
-    hash = ((hash << 5) + hash) + ptr->length();
-    for(unsigned int n=0; n<ptr->length(); n++)
-        hash = (hash * 33) + (*ptr)[n];
-    if (*hash_ptr != hash)
-    {
-        *hash_ptr = hash;
-        return true;
-    }
-    return false;
-}
 
 static bool collisionable_isChanged(void* data, void* prev_data_ptr)
 {
@@ -194,3 +179,6 @@ void MultiplayerObject::sendClientCommand(sf::Packet& packet)
         game_client->sendPacket(packet);
     }
 }
+#ifndef _MSC_VER
+#include "multiplayer.hpp"
+#endif /* _MSC_VER */

--- a/src/multiplayer.h
+++ b/src/multiplayer.h
@@ -243,5 +243,9 @@ template<class T> MultiplayerObject* createMultiplayerObject()
 {
     return new T();
 }
+#ifdef _MSC_VER
+// MFC: GCC does proper external template instantiation, VC++ doesn't.
+#include "multiplayer.hpp"
+#endif
 
 #endif//MULTIPLAYER_H

--- a/src/multiplayer.hpp
+++ b/src/multiplayer.hpp
@@ -1,0 +1,20 @@
+#ifndef _MULTIPLAYER_HPP_
+#define _MULTIPLAYER_HPP_
+
+template <> bool multiplayerReplicationFunctions<string>::isChanged(void* data, void* prev_data_ptr)
+{
+    string* ptr = (string*)data;
+    int64_t* hash_ptr = (int64_t*)prev_data_ptr;
+
+    int64_t hash = 5381;
+    hash = ((hash << 5) + hash) + ptr->length();
+    for(unsigned int n=0; n<ptr->length(); n++)
+        hash = (hash * 33) + (*ptr)[n];
+    if (*hash_ptr != hash)
+    {
+        *hash_ptr = hash;
+        return true;
+    }
+    return false;
+}
+#endif /* _MULTIPLAYER_HPP_ */

--- a/src/scriptInterface.cpp
+++ b/src/scriptInterface.cpp
@@ -670,47 +670,6 @@ P<ScriptObject> ScriptSimpleCallback::getScriptObject()
     return ret;
 }
 
-template<> void convert<ScriptSimpleCallback>::param(lua_State* L, int& idx, ScriptSimpleCallback& callback_object)
-{
-    if (lua_isnil(L, idx))
-    {
-        //Nil given as parameter to this callback, clear out the callback.
-        lua_pushlightuserdata(L, &callback_object);
-        lua_pushnil(L);
-        lua_settable(L, LUA_REGISTRYINDEX);
-        return;
-    }
-    //Check if the parameter is a function.
-    luaL_checktype(L, idx, LUA_TFUNCTION);
-    //Check if this function is a lua function, with an reference to the environment.
-    //  (We need the environment reference to see if the script to which the function belongs is destroyed when calling the callback)
-    if (lua_iscfunction(L, idx))
-        luaL_error(L, "Cannot set a binding as callback function.");
-    lua_getupvalue(L, idx, 1);
-    if (!lua_istable(L, -1))
-        luaL_error(L, "??? Upvalue 1 of function is not a table...");
-    //Stack is now: [function_environment]
-    
-    lua_pushlightuserdata(L, &callback_object);
-    lua_newtable(L);
-    lua_pushstring(L, "script_pointer");
-
-    //Stack is now: [function_environment] [callback object pointer] [table] "script_pointer"
-    lua_pushstring(L, "__script_pointer");
-    lua_gettable(L, -5);
-    if (!lua_islightuserdata(L, -1))
-        luaL_error(L, "??? Cannot find reference back to script...");
-    //Stack is now: [function_environment] [callback object pointer] [table] "script_pointer" [pointer to script object]
-    lua_rawset(L, -3);
-    //Stack is now: [function_environment] [callback object pointer] [table]
-    lua_pushstring(L, "function");
-    lua_pushvalue(L, idx);
-    //Stack is now: [function_environment] [callback object pointer] [table] "function" [lua function reference]
-    lua_rawset(L, -3);
-    
-    //Stack is now: [function_environment] [callback object pointer] [table]
-    lua_settable(L, LUA_REGISTRYINDEX);
-    lua_pop(L, 1);
-    
-    idx++;
-}
+#ifndef _MSC_VER
+#include "scriptInterface.hpp"
+#endif /* _MSC_VER */

--- a/src/scriptInterface.h
+++ b/src/scriptInterface.h
@@ -76,4 +76,9 @@ public:
 };
 template<> void convert<ScriptSimpleCallback>::param(lua_State* L, int& idx, ScriptSimpleCallback& callback);
 
+#ifdef _MSC_VER
+// MFC: GCC does proper external template instantiation, VC++ doesn't.
+#include "scriptInterface.hpp"
+#endif
+
 #endif//SCRIPT_INTERFACE_H

--- a/src/scriptInterface.hpp
+++ b/src/scriptInterface.hpp
@@ -1,0 +1,48 @@
+#ifndef _SCRIPTINTERFACE_HPP_
+#define _SCRIPTINTERFACE_HPP_
+
+template<> void convert<ScriptSimpleCallback>::param(lua_State* L, int& idx, ScriptSimpleCallback& callback_object)
+{
+    if (lua_isnil(L, idx))
+    {
+        //Nil given as parameter to this callback, clear out the callback.
+        lua_pushlightuserdata(L, &callback_object);
+        lua_pushnil(L);
+        lua_settable(L, LUA_REGISTRYINDEX);
+        return;
+    }
+    //Check if the parameter is a function.
+    luaL_checktype(L, idx, LUA_TFUNCTION);
+    //Check if this function is a lua function, with an reference to the environment.
+    //  (We need the environment reference to see if the script to which the function belongs is destroyed when calling the callback)
+    if (lua_iscfunction(L, idx))
+        luaL_error(L, "Cannot set a binding as callback function.");
+    lua_getupvalue(L, idx, 1);
+    if (!lua_istable(L, -1))
+        luaL_error(L, "??? Upvalue 1 of function is not a table...");
+    //Stack is now: [function_environment]
+    
+    lua_pushlightuserdata(L, &callback_object);
+    lua_newtable(L);
+    lua_pushstring(L, "script_pointer");
+
+    //Stack is now: [function_environment] [callback object pointer] [table] "script_pointer"
+    lua_pushstring(L, "__script_pointer");
+    lua_gettable(L, -5);
+    if (!lua_islightuserdata(L, -1))
+        luaL_error(L, "??? Cannot find reference back to script...");
+    //Stack is now: [function_environment] [callback object pointer] [table] "script_pointer" [pointer to script object]
+    lua_rawset(L, -3);
+    //Stack is now: [function_environment] [callback object pointer] [table]
+    lua_pushstring(L, "function");
+    lua_pushvalue(L, idx);
+    //Stack is now: [function_environment] [callback object pointer] [table] "function" [lua function reference]
+    lua_rawset(L, -3);
+    
+    //Stack is now: [function_environment] [callback object pointer] [table]
+    lua_settable(L, LUA_REGISTRYINDEX);
+    lua_pop(L, 1);
+    
+    idx++;
+}
+#endif /* _SCRIPTINTERFACE_HPP_ */

--- a/src/scriptInterfaceMagic.cpp
+++ b/src/scriptInterfaceMagic.cpp
@@ -50,58 +50,6 @@ string getScriptClassClassNameFromObject(P<PObject> object)
     return "";
 }
 
-template<> int convert<bool>::returnType(lua_State* L, bool b)
-{
-    lua_pushboolean(L, b);
-    return 1;
-}
-
-template<> int convert<string>::returnType(lua_State* L, string s)
-{
-    lua_pushstring(L, s.c_str());
-    return 1;
-}
-
-template<> void convert<const char*>::param(lua_State* L, int& idx, const char*& str)
-{
-    str = luaL_checkstring(L, idx++);
-}
-
-template<> void convert<string>::param(lua_State* L, int& idx, string& str)
-{
-    str = luaL_checkstring(L, idx++);
-}
-
-template<> void convert<bool>::param(lua_State* L, int& idx, bool& b)
-{
-    b = lua_toboolean(L, idx++);
-}
-
-template<> void convert<sf::Color>::param(lua_State* L, int& idx, sf::Color& color)
-{
-    color = sf::Color::White;
-    string str = string(luaL_checkstring(L, idx++)).lower();
-    if (str == "black") { color = sf::Color::Black; return; }
-    else if (str == "white") { color = sf::Color::White; return; }
-    else if (str == "red") { color = sf::Color::Red; return; }
-    else if (str == "green") { color = sf::Color::Green; return; }
-    else if (str == "blue") { color = sf::Color::Blue; return; }
-    else if (str == "yellow") { color = sf::Color::Yellow; return; }
-    else if (str == "magenta") { color = sf::Color::Magenta; return; }
-    else if (str == "cyan") { color = sf::Color::Cyan; return; }
-    
-    if (str.startswith("#") && str.length() == 7)
-    {
-        color.r = str.substr(1, 2).toInt(16);
-        color.g = str.substr(3, 2).toInt(16);
-        color.b = str.substr(5, 2).toInt(16);
-    }
-    
-    std::vector<string> parts = str.split(",");
-    if (parts.size() == 3)
-    {
-        color.r = parts[0].toInt();
-        color.g = parts[1].toInt();
-        color.b = parts[2].toInt();
-    }
-}
+#ifndef _MSC_VER
+#include "scriptInterfaceMagic.hpp"
+#endif /* ! _MSC_VER */

--- a/src/scriptInterfaceMagic.h
+++ b/src/scriptInterfaceMagic.h
@@ -48,7 +48,7 @@ template<typename T> struct convert
     {
         //If you get a compile error here, then the function you are trying to register has an parameter that is not handled by the specialized converters, nor
         // by the default number conversion.
-        t = luaL_checknumber(L, idx++);
+        t = (T) luaL_checknumber(L, idx++);
     }
     static int returnType(lua_State* L, T t)
     {
@@ -723,4 +723,8 @@ public:
     }\
     ScriptClassInfo scriptClassInfo ## F ( # F , "" , registerFunctionFunction ## F , NULL );
 
+#ifdef _MSC_VER
+// MFC: GCC does proper external template instantiation, VC++ doesn't.
+#include "scriptInterfaceMagic.hpp"
+#endif
 #endif//SCRIPT_INTERFACE_MAGIC_H

--- a/src/scriptInterfaceMagic.hpp
+++ b/src/scriptInterfaceMagic.hpp
@@ -1,0 +1,59 @@
+#ifndef _SCRIPTINTERFACEMAGIC_HPP_
+#define _SCRIPTINTERFACEMAGIC_HPP_
+
+template<> int convert<bool>::returnType(lua_State* L, bool b)
+{
+    lua_pushboolean(L, b);
+    return 1;
+}
+
+template<> int convert<string>::returnType(lua_State* L, string s)
+{
+    lua_pushstring(L, s.c_str());
+    return 1;
+}
+
+template<> void convert<const char*>::param(lua_State* L, int& idx, const char*& str)
+{
+    str = luaL_checkstring(L, idx++);
+}
+
+template<> void convert<string>::param(lua_State* L, int& idx, string& str)
+{
+    str = luaL_checkstring(L, idx++);
+}
+
+template<> void convert<bool>::param(lua_State* L, int& idx, bool& b)
+{
+    b = lua_toboolean(L, idx++);
+}
+
+template<> void convert<sf::Color>::param(lua_State* L, int& idx, sf::Color& color)
+{
+    color = sf::Color::White;
+    string str = string(luaL_checkstring(L, idx++)).lower();
+    if (str == "black") { color = sf::Color::Black; return; }
+    else if (str == "white") { color = sf::Color::White; return; }
+    else if (str == "red") { color = sf::Color::Red; return; }
+    else if (str == "green") { color = sf::Color::Green; return; }
+    else if (str == "blue") { color = sf::Color::Blue; return; }
+    else if (str == "yellow") { color = sf::Color::Yellow; return; }
+    else if (str == "magenta") { color = sf::Color::Magenta; return; }
+    else if (str == "cyan") { color = sf::Color::Cyan; return; }
+    
+    if (str.startswith("#") && str.length() == 7)
+    {
+        color.r = str.substr(1, 2).toInt(16);
+        color.g = str.substr(3, 2).toInt(16);
+        color.b = str.substr(5, 2).toInt(16);
+    }
+    
+    std::vector<string> parts = str.split(",");
+    if (parts.size() == 3)
+    {
+        color.r = parts[0].toInt();
+        color.g = parts[1].toInt();
+        color.b = parts[2].toInt();
+    }
+}
+#endif /* _SCRIPTINTERFACEMAGIC_HPP_ */

--- a/src/stringImproved.h
+++ b/src/stringImproved.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <sstream>
 #include <iomanip>
+#include <algorithm> // MFC -- std::min std::max on Win32/MSDEV
 
 /*
     The improved string class. while this class is not always the most efficient in terms of execution speed.
@@ -28,19 +29,21 @@ public:
         push_back(c);
     }
 
-    string(const int nr) : std::string()
+    template<typename T> string(const T nr) : std::string()
     {
         std::ostringstream stream;
         stream << nr;
         *this = stream.str();
     }
 
+	/*
     string(const unsigned int nr) : std::string()
     {
         std::ostringstream stream;
         stream << nr;
         *this = stream.str();
     }
+	*/
 
     string(const float nr, int decimals = 2) : std::string()
     {
@@ -141,7 +144,8 @@ public:
     {
         if (suffix.length() == 0)
             return true;
-        return substr(-suffix.length()) == suffix;
+		// MFC: length() returns size_t which is unsigned.
+        return substr(-(int)suffix.length()) == suffix;
     }
 
     /*

--- a/src/stringImproved.h
+++ b/src/stringImproved.h
@@ -29,21 +29,29 @@ public:
         push_back(c);
     }
 
-    template<typename T> string(const T nr) : std::string()
+    string(const int nr) : std::string()
     {
         std::ostringstream stream;
         stream << nr;
         *this = stream.str();
     }
 
-	/*
     string(const unsigned int nr) : std::string()
     {
         std::ostringstream stream;
         stream << nr;
         *this = stream.str();
     }
-	*/
+
+#ifdef _MSC_VER
+    // MFC: size_t is __uint64 on Win32.
+    string(const size_t nr) : std::string()
+    {
+        std::ostringstream stream;
+        stream << nr;
+        *this = stream.str();
+    }
+#endif
 
     string(const float nr, int decimals = 2) : std::string()
     {

--- a/src/tween.cpp
+++ b/src/tween.cpp
@@ -1,11 +1,6 @@
 #include "tween.h"
 
-template<> sf::Color Tween<sf::Color>::tweenApply(float f, const sf::Color& value0, const sf::Color& value1)
-{
-    return sf::Color(
-        value0.r + (value1.r - value0.r) * f,
-        value0.g + (value1.g - value0.g) * f,
-        value0.b + (value1.b - value0.b) * f,
-        value0.a + (value1.a - value0.a) * f
-    );
-}
+#ifndef _MSC_VER
+// MFC: GCC does proper external template instantiation, VC++ doesn't.
+#include "tween.hpp"
+#endif /* _MSC_VER */

--- a/src/tween.h
+++ b/src/tween.h
@@ -45,4 +45,9 @@ public:
 
 template<> sf::Color Tween<sf::Color>::tweenApply(float f, const sf::Color& value0, const sf::Color& value1);
 
+#ifdef _MSC_VER
+// MFC: GCC does proper external template instantiation, VC++ doesn't.
+#include "tween.hpp"
+#endif
+
 #endif//TWEEN_H

--- a/src/tween.hpp
+++ b/src/tween.hpp
@@ -1,0 +1,13 @@
+#ifndef _MSC_VER
+#include "tween.h"
+#endif
+
+template<> sf::Color Tween<sf::Color>::tweenApply(float f, const sf::Color& value0, const sf::Color& value1)
+{
+    return sf::Color(
+        value0.r + (value1.r - value0.r) * f,
+        value0.g + (value1.g - value0.g) * f,
+        value0.b + (value1.b - value0.b) * f,
+        value0.a + (value1.a - value0.a) * f
+    );
+}


### PR DESCRIPTION
Primary changes are to move template specialization definitions into separate header files (.hpp).  The .hpp is included in the .cpp for GCC, but included in the .h file for MSVC.

There are a few other minor issues (VC++ doesn't do non-const dynamic allocations) and a few extra includes added.

The compile succeeds with a HUGE number of warnings, most of the related to the fact that size_t is defined as __uint64, but is cast to int in many places
