### PR TITLE
Add looping sounds

### DIFF
--- a/src/soundManager.cpp
+++ b/src/soundManager.cpp
@@ -74,12 +74,51 @@ float SoundManager::getMusicVolume()
 void SoundManager::stopSound(int index)
 {
     sf::Sound& sound = activeSoundList[index];
-    if (sound.getStatus() != sf::Sound::Stopped)
+    if (sound.getStatus() == sf::Sound::Playing)
     {
         sound.setLoop(false);
         sound.stop();
     }
-    return;
+}
+
+void SoundManager::setSoundVolume(int index, float volume)
+{
+    sf::Sound& sound = activeSoundList[index];
+    if (sound.getStatus() == sf::Sound::Playing)
+    {
+        // Bound volume between 0.0f and 100.0f.
+        volume = std::max(0.0f, std::min(100.0f, volume));
+        sound.setVolume(volume);
+    }
+}
+
+float SoundManager::getSoundVolume(int index)
+{
+    sf::Sound& sound = activeSoundList[index];
+    if (sound.getStatus() == sf::Sound::Playing)
+    {
+        return sound.getVolume();
+    }
+}
+
+void SoundManager::setSoundPitch(int index, float pitch)
+{
+    sf::Sound& sound = activeSoundList[index];
+    if (sound.getStatus() == sf::Sound::Playing)
+    {
+        // Bound pitch to 0.0f or greater.
+        pitch = std::max(0.0f, pitch);
+        sound.setPitch(pitch);
+    }
+}
+
+float SoundManager::getSoundPitch(int index)
+{
+    sf::Sound& sound = activeSoundList[index];
+    if (sound.getStatus() == sf::Sound::Playing)
+    {
+        return sound.getPitch();
+    }
 }
 
 int SoundManager::playSound(string name, float pitch, float volume, bool loop)

--- a/src/soundManager.cpp
+++ b/src/soundManager.cpp
@@ -82,7 +82,7 @@ void SoundManager::stopSound(int index)
     return;
 }
 
-int SoundManager::playSound(string name, float pitch, float volume)
+int SoundManager::playSound(string name, float pitch, float volume, bool loop)
 {
     sf::SoundBuffer* data = soundMap[name];
     if (data == NULL)
@@ -90,7 +90,7 @@ int SoundManager::playSound(string name, float pitch, float volume)
 
     // Return the sound's index in activeSoundList[].
     // Returns -1 if the list was full of playing sounds.
-    return playSoundData(data, pitch, volume);
+    return playSoundData(data, pitch, volume, loop);
 }
 
 void SoundManager::setListenerPosition(sf::Vector2f position, float angle)
@@ -106,7 +106,7 @@ void SoundManager::disablePositionalSound()
     positional_sound_enabled = false;
 }
 
-int SoundManager::playSound(string name, sf::Vector2f position, float min_distance, float attenuation, float pitch, float volume)
+int SoundManager::playSound(string name, sf::Vector2f position, float min_distance, float attenuation, float pitch, float volume, bool loop)
 {
     if (!positional_sound_enabled)
         return -1;
@@ -128,6 +128,7 @@ int SoundManager::playSound(string name, sf::Vector2f position, float min_distan
             sound.setPosition(position.x, 0, position.y);
             sound.setPitch(pitch);
             sound.setVolume(volume);
+            sound.setLoop(loop);
             sound.play();
             return n;
         }
@@ -165,7 +166,7 @@ void SoundManager::playTextToSpeech(string text)
     sf::SoundBuffer* data = soundMap[name];
     if (data != NULL)
     {
-        playSoundData(data, 1.0, 100.0);
+        playSoundData(data, 1.0, 100.0, false);
         return;
     }
 
@@ -180,7 +181,7 @@ void SoundManager::playTextToSpeech(string text)
         sf::SoundBuffer* data = new sf::SoundBuffer();
         data->loadFromMemory(wave.data(), wave.size());
         soundMap[name] = data;
-        playSoundData(data, 1.0, 100.0);
+        playSoundData(data, 1.0, 100.0, false);
     }
     else
     {
@@ -188,7 +189,7 @@ void SoundManager::playTextToSpeech(string text)
     }
 }
 
-int SoundManager::playSoundData(sf::SoundBuffer* data, float pitch, float volume)
+int SoundManager::playSoundData(sf::SoundBuffer* data, float pitch, float volume, bool loop)
 {
     for(int n = 0; n < activeSoundList.size(); n++)
     {
@@ -202,14 +203,13 @@ int SoundManager::playSoundData(sf::SoundBuffer* data, float pitch, float volume
             sound.setPitch(pitch);
             sound.setVolume(volume);
             sound.setPosition(0, 0, 0);
+            sound.setLoop(loop);
             sound.play();
-            LOG(INFO) << "Playing sound. Returning " << string(n);
             return n;
         }
     }
 
     // No room in activeSoundList; return -1.
-    LOG(INFO) << "Not playing sound. Returning -1.";
     return -1;
 }
 

--- a/src/soundManager.cpp
+++ b/src/soundManager.cpp
@@ -116,7 +116,7 @@ int SoundManager::playSound(string name, sf::Vector2f position, float min_distan
     if (data->getChannelCount() > 1)
         LOG(WARNING) << name << ": Used as positional sound but has more than 1 channel.";
 
-    for(int n = 0; n < activeSoundList.size(); n++)
+    for(unsigned int n = 0; n < activeSoundList.size(); n++)
     {
         sf::Sound& sound = activeSoundList[n];
         if (sound.getStatus() == sf::Sound::Stopped)
@@ -130,9 +130,12 @@ int SoundManager::playSound(string name, sf::Vector2f position, float min_distan
             sound.setVolume(volume);
             sound.setLoop(loop);
             sound.play();
-            return n;
+            return int(n);
         }
     }
+
+    // No room in activeSoundList; return -1.
+    return -1;
 }
 
 void SoundManager::setTextToSpeachVoice(string name)
@@ -191,7 +194,7 @@ void SoundManager::playTextToSpeech(string text)
 
 int SoundManager::playSoundData(sf::SoundBuffer* data, float pitch, float volume, bool loop)
 {
-    for(int n = 0; n < activeSoundList.size(); n++)
+    for(unsigned int n = 0; n < activeSoundList.size(); n++)
     {
         sf::Sound& sound = activeSoundList[n];
         if (sound.getStatus() == sf::Sound::Stopped)
@@ -205,7 +208,7 @@ int SoundManager::playSoundData(sf::SoundBuffer* data, float pitch, float volume
             sound.setPosition(0, 0, 0);
             sound.setLoop(loop);
             sound.play();
-            return n;
+            return int(n);
         }
     }
 

--- a/src/soundManager.h
+++ b/src/soundManager.h
@@ -31,9 +31,9 @@ private:
     };
     sf::Clock clock;
     MusicChannel music_channel;
-    
+
     std::vector<string> music_set;
-    
+
     std::unordered_map<string, sf::SoundBuffer*> soundMap;
     std::vector<sf::Sound> activeSoundList;
     float music_volume;
@@ -41,30 +41,31 @@ private:
 public:
     SoundManager();
     ~SoundManager();
-    
+
     void playMusic(string filename);
     void playMusicSet(std::vector<string> filenames);
     void stopMusic();
     void setMusicVolume(float volume);
     float getMusicVolume();
-    void playSound(string name, float pitch = 1.0f, float volume = 100.0f);
+    int playSound(string name, float pitch = 1.0f, float volume = 100.0f);
 
-    //Positional sounds
+    // Positional sounds
     void setListenerPosition(sf::Vector2f position, float angle);
     void disablePositionalSound();
-    void playSound(string name, sf::Vector2f position, float min_distance, float attenuation, float pitch = 1.0f, float volume = 100.0f);
+    void stopSound(int index);
+    int playSound(string name, sf::Vector2f position, float min_distance, float attenuation, float pitch = 1.0f, float volume = 100.0f);
 
     void setTextToSpeachVoice(string name);
     void playTextToSpeech(string text);
 private:
-    void playSoundData(sf::SoundBuffer* data, float pitch, float volume);
+    int playSoundData(sf::SoundBuffer* data, float pitch, float volume);
     sf::SoundBuffer* loadSound(string name);
-    
+
     void startMusic(P<ResourceStream> stream, bool loop=false);
-    
+
     void updateTick();
     void updateChannel(MusicChannel& channel, float delta);
-    
+
     friend class Engine;
 };
 

--- a/src/soundManager.h
+++ b/src/soundManager.h
@@ -14,6 +14,7 @@ class SoundManager
 {
 private:
     static constexpr float fade_music_time = 1.0;
+    static constexpr float fade_sound_time = 0.3;
 
     enum FadeMode
     {
@@ -42,19 +43,29 @@ public:
     SoundManager();
     ~SoundManager();
 
+    // Music
     void playMusic(string filename);
     void playMusicSet(std::vector<string> filenames);
     void stopMusic();
     void setMusicVolume(float volume);
     float getMusicVolume();
+
+    // Non-positional sounds
     int playSound(string name, float pitch = 1.0f, float volume = 100.0f, bool loop = false);
 
     // Positional sounds
+    int playSound(string name, sf::Vector2f position, float min_distance, float attenuation, float pitch = 1.0f, float volume = 100.0f, bool loop = false);
     void setListenerPosition(sf::Vector2f position, float angle);
     void disablePositionalSound();
-    void stopSound(int index);
-    int playSound(string name, sf::Vector2f position, float min_distance, float attenuation, float pitch = 1.0f, float volume = 100.0f, bool loop = false);
 
+    // Sound management
+    void stopSound(int index);
+    void setSoundVolume(int index, float volume); // Valid values 0.0f-100.0f
+    float getSoundVolume(int index);
+    void setSoundPitch(int index, float volume); // Valid values 0.0f+; 1.0 = default
+    float getSoundPitch(int index);
+
+    // TTS
     void setTextToSpeachVoice(string name);
     void playTextToSpeech(string text);
 private:

--- a/src/soundManager.h
+++ b/src/soundManager.h
@@ -47,18 +47,18 @@ public:
     void stopMusic();
     void setMusicVolume(float volume);
     float getMusicVolume();
-    int playSound(string name, float pitch = 1.0f, float volume = 100.0f);
+    int playSound(string name, float pitch = 1.0f, float volume = 100.0f, bool loop = false);
 
     // Positional sounds
     void setListenerPosition(sf::Vector2f position, float angle);
     void disablePositionalSound();
     void stopSound(int index);
-    int playSound(string name, sf::Vector2f position, float min_distance, float attenuation, float pitch = 1.0f, float volume = 100.0f);
+    int playSound(string name, sf::Vector2f position, float min_distance, float attenuation, float pitch = 1.0f, float volume = 100.0f, bool loop = false);
 
     void setTextToSpeachVoice(string name);
     void playTextToSpeech(string text);
 private:
-    int playSoundData(sf::SoundBuffer* data, float pitch, float volume);
+    int playSoundData(sf::SoundBuffer* data, float pitch, float volume, bool loop = false);
     sf::SoundBuffer* loadSound(string name);
 
     void startMusic(P<ResourceStream> stream, bool loop=false);


### PR DESCRIPTION
-   Add a `loop` parameter to `playSound()` and `playSoundData()`

    ```
    playSound(string name, float pitch = 1.0f, float volume = 100.0f, bool loop = false);
    ```

    If `looping` is `true`, loop the sound effect. Since it defaults to false, there's no change to existing behavior and other `playSound`/`playSoundData` calls work without modification.

    See [EmptyEpsilon PR #358](https://github.com/daid/EmptyEpsilon/pull/358) for a live example.

-    Make `playSound()` and `playSoundData()` return the sound's index in `activeSoundList`, so we can manipulate it later.

-   Add `stopSound(int index)` to stop a sound's playback.

It looks like my text editor converted inconsistent line breaks. The primary changes are

-   L73-84 (`stopSound()`)
-   L85 and 93 (add `loop` parameter to non-positional `playSound()`, return int from `playSound()`)
-   L105-139 (add `loop` parameter to positional `playSound()`, return int, return -1 on failure/no sound)
-   L195-217 (add `loop` parameter to `playSoundData()`, return int)