### PR TITLE
Add forceMemberReplicationUpdate method

### DIFF
--- a/src/multiplayer.h
+++ b/src/multiplayer.h
@@ -211,6 +211,13 @@ public:
                 memberReplicationInfo[n].update_delay = update_delay;
     }
 
+    void forceMemberReplicationUpdate(void* data)
+    {
+        for(unsigned int n=0; n<memberReplicationInfo.size(); n++)
+            if (memberReplicationInfo[n].ptr == data)
+                memberReplicationInfo[n].update_timeout = 0.0;
+    }
+
     void registerCollisionableReplication(float object_significant_range = -1);
 
     int32_t getMultiplayerId() { return multiplayerObjectId; }


### PR DESCRIPTION
Pretty straightforward. This is for any replicated member that would normally have a delay on its updates; this method says, screw the delay, do it right now and reset the timer for the next interval. My pull request in EmptyEpsilon will use this.
https://github.com/daid/EmptyEpsilon/pull/568