### PR TITLE
Added missing returnType templates

### DIFF
--- a/src/multiplayer.h
+++ b/src/multiplayer.h
@@ -211,13 +211,6 @@ public:
                 memberReplicationInfo[n].update_delay = update_delay;
     }
 
-    void forceMemberReplicationUpdate(void* data)
-    {
-        for(unsigned int n=0; n<memberReplicationInfo.size(); n++)
-            if (memberReplicationInfo[n].ptr == data)
-                memberReplicationInfo[n].update_timeout = 0.0;
-    }
-
     void registerCollisionableReplication(float object_significant_range = -1);
 
     int32_t getMultiplayerId() { return multiplayerObjectId; }

--- a/src/multiplayer.h
+++ b/src/multiplayer.h
@@ -211,6 +211,13 @@ public:
                 memberReplicationInfo[n].update_delay = update_delay;
     }
 
+    void forceMemberReplicationUpdate(void* data)
+    {
+        for(unsigned int n=0; n<memberReplicationInfo.size(); n++)
+            if (memberReplicationInfo[n].ptr == data)
+                memberReplicationInfo[n].update_timeout = 0.0;
+    }
+
     void registerCollisionableReplication(float object_significant_range = -1);
 
     int32_t getMultiplayerId() { return multiplayerObjectId; }

--- a/src/scriptInterfaceMagic.h
+++ b/src/scriptInterfaceMagic.h
@@ -58,6 +58,10 @@ template<typename T> struct convert
 };
 //Specialized template for the bool return type, so we return a lua boolean.
 template<> int convert<bool>::returnType(lua_State* L, bool b);
+//Specialized template for the long return type, so we return a lua 64-bit integer.
+template<> int convert<long>::returnType(lua_State* L, long b);
+//Specialized template for the int return type, so we return a lua 32-bit integer.
+template<> int convert<int>::returnType(lua_State* L, int b);
 //Specialized template for the string return type, so we return a lua string.
 template<> int convert<string>::returnType(lua_State* L, string s);
 


### PR DESCRIPTION
These are needed in the header file with the merging of https://github.com/daid/SeriousProton/pull/23 because otherwise I get "multiple definition" build errors.

Please ignore the earlier of the two commits, it's from my master branch and this separate branch was created afterward. It has been removed from this pull request.