### PR TITLE
Fixed crash when client connects with wrong version.

### DIFF
--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -211,8 +211,8 @@ void GameServer::update(float gameDelta)
                                     }
                                 }else{
                                     LOG(ERROR) << n << ":Client version mismatch: " << version_number << " != " << client_version;
-                                    clientList[n].socket->disconnect();
                                     selector.remove(*clientList[n].socket);
+                                    clientList[n].socket->disconnect();
                                     clientList[n].socket = NULL;
                                 }
                                 break;
@@ -220,8 +220,8 @@ void GameServer::update(float gameDelta)
                             break;
                         default:
                             LOG(ERROR) << "Unknown command from client while authenticating: " << command;
-                            clientList[n].socket->disconnect();
                             selector.remove(*clientList[n].socket);
+                            clientList[n].socket->disconnect();
                             clientList[n].socket = NULL;
                             break;
                         }


### PR DESCRIPTION
What you did did not quite fix it.

The crash was happening because `disconnect` was called while the socket was in the selector.