### PR TITLE
Support keep alives while waiting for client auth

### DIFF
--- a/src/multiplayer_client.cpp
+++ b/src/multiplayer_client.cpp
@@ -52,6 +52,7 @@ void GameClient::update(float delta)
         objectMap.erase(delList[n]);
 
     socket.update();
+    sf::Packet reply;
     sf::Packet packet;
     sf::TcpSocket::Status socket_status;
     while((socket_status = socket.receive(packet)) == sf::TcpSocket::Done)
@@ -76,7 +77,7 @@ void GameClient::update(float delta)
                     
                     if (!require_password)
                     {
-                        sf::Packet reply;
+                        reply.clear();
                         reply << CMD_CLIENT_SEND_AUTH << int32_t(version_number) << string("");
                         socket.send(reply);
                     }else{
@@ -89,7 +90,10 @@ void GameClient::update(float delta)
                 status = Connected;
                 break;
             case CMD_ALIVE:
-                //Alive packet, just to keep the connection alive.
+                // send response to calculate ping
+                reply.clear();
+                reply << CMD_ALIVE_RESP;
+                socket.send(reply);
                 break;
             default:
                 LOG(ERROR) << "Unknown command from server: " << command;
@@ -167,7 +171,10 @@ void GameClient::update(float delta)
                 }
                 break;
             case CMD_ALIVE:
-                //Alive packet, just to keep the connection alive.
+                // send response to calculate ping
+                reply.clear();
+                reply << CMD_ALIVE_RESP;
+                socket.send(reply);
                 break;
             default:
                 LOG(ERROR) << "Unknown command from server: " << command;

--- a/src/multiplayer_internal.h
+++ b/src/multiplayer_internal.h
@@ -14,5 +14,6 @@ static const command_t CMD_CLIENT_AUDIO_COMM = 0x0008;
 static const command_t CMD_REQUEST_AUTH = 0x0009;
 static const command_t CMD_CLIENT_SEND_AUTH = 0x0010;
 static const command_t CMD_SERVER_COMMAND = 0x0011;
+static const command_t CMD_ALIVE_RESP = 0x0012;
 
 #endif//MULTIPLAYER_INTERNAL_H

--- a/src/multiplayer_server.h
+++ b/src/multiplayer_server.h
@@ -48,6 +48,8 @@ class GameServer : public Updatable
         int32_t client_id;
         EClientReceiveState receive_state;
         int32_t command_object_id;
+        sf::Clock round_trip_time;
+        int32_t ping;
     };
     int32_t nextclient_id;
     std::vector<ClientInfo> clientList;
@@ -80,6 +82,7 @@ public:
 private:
     void registerObject(P<MultiplayerObject> obj);
     void broadcastServerCommandFromObject(int32_t id, sf::Packet& packet);
+    void keepAliveAll();
     void sendAll(sf::Packet& packet);
 
     void generateCreatePacketFor(P<MultiplayerObject> obj, sf::Packet& packet);


### PR DESCRIPTION
https://github.com/daid/EmptyEpsilon/issues/629 reports an issue where the timeout for entering a password is too short. Based on investigation, the timeout is from the multiplayer_client no_data_disconnect_time (20 seconds). I didn't want to extend this timeout since it is likely valid, and I didn't want un-authenticated clients to force the server to have to track their state and issue keep alives to them. So the solution I came up with is to add a keepAlive() function to the client that the client can perdiocically send while waiting for input (requires changes in EmptyEpsilon). Then I updated the server to accept the CMD_ALIVE packets while waiting for auth, and upon receiving the packet, re-request auth to make sure the client gets a packet to restart the timer.

Note: it shows that a few random lines were touched, I think that was my editor just changing the line ending. I can try to fix that if need be