### PR TITLE
Address server hang

### DIFF
--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -356,6 +356,7 @@ void GameServer::handleBroadcastUDPSocket(float delta)
         sf::IpAddress recvAddress;
         unsigned short recvPort;
         sf::Packet recvPacket;
+        broadcast_listen_socket.SetBlocking(false);
         broadcast_listen_socket.receive(recvPacket, recvAddress, recvPort);
 
         //We do not care about what we received. Reply that we live!


### PR DESCRIPTION
Testing showed that by making the UDP port non-blocking, this particular server hang stopped occurring. Thanks to Starry for finding this and suggesting this modification.