### PR TITLE
Log client/server version mismatch on clients

### DIFF
--- a/src/multiplayer_client.cpp
+++ b/src/multiplayer_client.cpp
@@ -74,6 +74,11 @@ void GameClient::update(float delta)
                     int32_t server_version;
                     bool require_password;
                     packet >> server_version >> require_password;
+
+		    if (server_version != 0 && server_version != version_number)
+		    {
+                        LOG(INFO) << "Server version " << server_version << " does not match client version " << version_number;
+		    }
                     
                     if (!require_password)
                     {


### PR DESCRIPTION
If the client detects that the server version is neither 0 nor the same as the client version, log this detail.

Fixes daid/EmptyEpsilon#244.