### PR TITLE
Log master server URL on info, warn, and error messages.

### DIFF
--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -452,20 +452,20 @@ void GameServer::runMasterServerUpdateThread()
 {
     if (!master_server_url.startswith("http://"))
     {
-        LOG(ERROR) << "Master server URL does not start with \"http://\"";
+        LOG(ERROR) << "Master server URL " << master_server_url << " does not start with \"http://\"";
         return;
     }
     string hostname = master_server_url.substr(7);
     int path_start = hostname.find("/");
     if (path_start < 0)
     {
-        LOG(ERROR) << "Master server URL has no uri after hostname";
+        LOG(ERROR) << "Master server URL " << master_server_url << " does not have a URI after the hostname";
         return;
     }
     string uri = hostname.substr(path_start + 1);
     hostname = hostname.substr(0, path_start);
     
-    LOG(INFO) << "Registering at master server";
+    LOG(INFO) << "Registering at master server " << master_server_url;
     
     sf::Http http(hostname);
     while(!isDestroyed() && master_server_url != "")
@@ -476,10 +476,10 @@ void GameServer::runMasterServerUpdateThread()
         sf::Http::Response response = http.sendRequest(request, sf::seconds(10.0f));
         if (response.getStatus() != sf::Http::Response::Ok)
         {
-            LOG(WARNING) << "Failed to register at master server (" << response.getStatus() << ")";
+            LOG(WARNING) << "Failed to register at master server " << master_server_url << " (status " << response.getStatus() << ")";
         }else if (response.getBody() != "OK")
         {
-            LOG(WARNING) << "Master server reports error on registering: " << response.getBody();
+            LOG(WARNING) << "Master server " << master_server_url << " reports error on registering: " << response.getBody();
         }
         
         for(int n=0;n<60 && !isDestroyed() && master_server_url != "";n++)

--- a/src/multiplayer_server_scanner.cpp
+++ b/src/multiplayer_server_scanner.cpp
@@ -139,20 +139,20 @@ void ServerScanner::masterServerScanThread()
 {
     if (!master_server_url.startswith("http://"))
     {
-        LOG(ERROR) << "Master server URL does not start with \"http://\"";
+        LOG(ERROR) << "Master server URL " << master_server_url << " does not start with \"http://\"";
         return;
     }
     string hostname = master_server_url.substr(7);
     int path_start = hostname.find("/");
     if (path_start < 0)
     {
-        LOG(ERROR) << "Master server URL has no uri after hostname";
+        LOG(ERROR) << "Master server URL " << master_server_url << " does not have a URI after the hostname";
         return;
     }
     string uri = hostname.substr(path_start + 1);
     hostname = hostname.substr(0, path_start);
     
-    LOG(INFO) << "Reading servers from master server";
+    LOG(INFO) << "Reading servers from master server " << master_server_url;
     
     sf::Http http(hostname);
     while(!isDestroyed() && master_server_url != "")
@@ -162,7 +162,7 @@ void ServerScanner::masterServerScanThread()
         
         if (response.getStatus() != sf::Http::Response::Ok)
         {
-            LOG(WARNING) << "Failed to query master server (" << response.getStatus() << ")";
+            LOG(WARNING) << "Failed to query master server " << master_server_url << " (status " << response.getStatus() << ")";
         }
         for(string line : string(response.getBody()).split("\n"))
         {


### PR DESCRIPTION
Logs the URL used for the master server.

Supports PR daid/EmptyEpsilon#722.