### PR TITLE
Parse the master server's port if specified

### DIFF
--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -462,12 +462,22 @@ void GameServer::runMasterServerUpdateThread()
         LOG(ERROR) << "Master server URL " << master_server_url << " does not have a URI after the hostname";
         return;
     }
+    int port = 80;
+    int port_start = hostname.find(":");
     string uri = hostname.substr(path_start + 1);
-    hostname = hostname.substr(0, path_start);
+    if (port_start >= 0)
+    {
+        // If a port is attached to the hostname, parse it out.
+        // No validation is performed.
+        port = hostname.substr(port_start + 1, hostname.length() - port_start + 1).toInt();
+        hostname = hostname.substr(0, port_start);
+    }else{
+        hostname = hostname.substr(0, path_start);
+    }
     
     LOG(INFO) << "Registering at master server " << master_server_url;
     
-    sf::Http http(hostname);
+    sf::Http http(hostname, port);
     while(!isDestroyed() && master_server_url != "")
     {
         sf::Http::Request request(uri, sf::Http::Request::Post);

--- a/src/multiplayer_server_scanner.cpp
+++ b/src/multiplayer_server_scanner.cpp
@@ -149,12 +149,23 @@ void ServerScanner::masterServerScanThread()
         LOG(ERROR) << "Master server URL " << master_server_url << " does not have a URI after the hostname";
         return;
     }
+
+    int port = 80;
+    int port_start = hostname.find(":");
     string uri = hostname.substr(path_start + 1);
-    hostname = hostname.substr(0, path_start);
-    
+    if (port_start >= 0)
+    {
+        // If a port is attached to the hostname, parse it out.
+        // No validation is performed.
+        port = hostname.substr(port_start + 1, hostname.length() - port_start + 1).toInt();
+        hostname = hostname.substr(0, port_start);
+    }else{
+        hostname = hostname.substr(0, path_start);
+    }
+
     LOG(INFO) << "Reading servers from master server " << master_server_url;
-    
-    sf::Http http(hostname);
+
+    sf::Http http(hostname, port);
     while(!isDestroyed() && master_server_url != "")
     {
         sf::Http::Request request(uri, sf::Http::Request::Get);


### PR DESCRIPTION
Allow for the registry master server to be served on a port
other than 80 by parsing it out of the URL if present.