### PR TITLE
Resolve compiler warnings

### DIFF
--- a/src/PlayerController.cpp
+++ b/src/PlayerController.cpp
@@ -1,7 +1,6 @@
 #include "PlayerController.h"
 
 PlayerController::PlayerController(int nr)
-: index(nr)
 {
     switch(nr)
     {

--- a/src/PlayerController.h
+++ b/src/PlayerController.h
@@ -5,7 +5,6 @@
 #include "windowManager.h"
 class PlayerController: public virtual PObject
 {
-    int index;
 public:
     static const int buttonCount = 6;
     sf::Keyboard::Key keyBind[4 + buttonCount];

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -107,7 +107,7 @@ void Engine::runMainLoop()
 
             if (debugOutputClock.getElapsedTime().asSeconds() > 1.0)
             {
-                printf("Object count: %4d %4d %4d\n", DEBUG_PobjCount, updatableList.size(), entityList.size());
+                printf("Object count: %4d %4ld %4ld\n", DEBUG_PobjCount, updatableList.size(), entityList.size());
                 debugOutputClock.restart();
             }
 #endif
@@ -153,7 +153,7 @@ void Engine::runMainLoop()
 void Engine::handleEvent(sf::Event& event)
 {
     // Window closed: exit
-    if ((event.type == sf::Event::Closed))
+    if (event.type == sf::Event::Closed)
         running = false;
     if (event.type == sf::Event::GainedFocus)
         windowManager->windowHasFocus = true;

--- a/src/httpServer.h
+++ b/src/httpServer.h
@@ -72,7 +72,6 @@ private:
 class HttpServer: public Updatable
 {
 private:
-    int portNr;
     sf::TcpListener listenSocket;
     sf::SocketSelector selector;
     std::vector<HttpServerConnection*> connections;

--- a/src/multiplayer_proxy.h
+++ b/src/multiplayer_proxy.h
@@ -28,7 +28,6 @@ class GameServerProxy : public Updatable
     std::vector<ClientInfo> clientList;
     std::unordered_set<int32_t> targetClients;
 
-    int32_t nextFakeClientId = 1;
     int32_t clientId = 0;
     string password;
     int32_t serverVersion = 0;
@@ -40,7 +39,7 @@ public:
 
     virtual void destroy() override;
 
-    virtual void update(float delta);
+    virtual void update(float delta) override;
 private:
     void sendAll(sf::Packet& packet);
 };

--- a/src/multiplayer_server.h
+++ b/src/multiplayer_server.h
@@ -74,7 +74,7 @@ public:
     virtual void destroy() override;
 
     P<MultiplayerObject> getObjectById(int32_t id);
-    virtual void update(float delta);
+    virtual void update(float delta) override;
     inline float getSendDataRate() { return sendDataRate; }
     inline float getSendDataRatePerClient() { return sendDataRatePerClient; }
     inline float getUpdateTime() { return update_run_time; }


### PR DESCRIPTION
Remove unused private members HttpServer portNr and PlayerController index; specify long-type arguments to printf; add explicit function overrides. Rest of the changes are editor-converted line breaks.