### PR TITLE
Fix some undefined behaviours

### DIFF
--- a/src/dtoa/dtoa_milo.h
+++ b/src/dtoa/dtoa_milo.h
@@ -291,7 +291,8 @@ inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buff
 	}
 
 	// kappa = 0
-	for (;;) {
+	assert(*len >= 0);
+	for (; static_cast<std::size_t>(*len) < sizeof(buffer);) {
 		p2 *= 10;
 		delta *= 10;
 		char d = static_cast<char>(p2 >> -one.e);

--- a/src/multiplayer.cpp
+++ b/src/multiplayer.cpp
@@ -49,9 +49,9 @@ MultiplayerObject::~MultiplayerObject()
 template <> bool multiplayerReplicationFunctions<string>::isChanged(void* data, void* prev_data_ptr)
 {
     string* ptr = (string*)data;
-    int64_t* hash_ptr = (int64_t*)prev_data_ptr;
+    uintptr_t* hash_ptr = (uintptr_t*)prev_data_ptr;
 
-    int64_t hash = 5381;
+    uintptr_t hash = 5381;
     hash = ((hash << 5) + hash) + ptr->length();
     for(unsigned int n=0; n<ptr->length(); n++)
         hash = (hash * 33) + (*ptr)[n];
@@ -171,7 +171,7 @@ void MultiplayerObject::registerCollisionableReplication(float object_significan
 #ifdef DEBUG
     info.name = "Collisionable_data";
 #endif
-    info.prev_data = (int64_t)new CollisionableReplicationData();
+    info.prev_data = new CollisionableReplicationData();
     info.update_delay = 0.0;
     info.update_timeout = 0.0;
     info.isChangedFunction = &collisionable_isChanged;

--- a/src/multiplayer.cpp
+++ b/src/multiplayer.cpp
@@ -171,7 +171,7 @@ void MultiplayerObject::registerCollisionableReplication(float object_significan
 #ifdef DEBUG
     info.name = "Collisionable_data";
 #endif
-    info.prev_data = new CollisionableReplicationData();
+    info.prev_data = reinterpret_cast<std::uint64_t>(new CollisionableReplicationData());
     info.update_delay = 0.0;
     info.update_timeout = 0.0;
     info.isChangedFunction = &collisionable_isChanged;

--- a/src/multiplayer.h
+++ b/src/multiplayer.h
@@ -171,7 +171,20 @@ public:
         info.name = name;
 #endif
         info.ptr = member;
-        info.prev_data = reinterpret_cast<std::uint64_t>(nullptr);
+        static_assert(
+                std::is_same<T, string>::value ||
+                (
+                        std::is_default_constructible<T>::value &&
+                        std::is_trivially_destructible<T>::value &&
+                        sizeof(T) <= 8
+                ),
+                "T must be a string or must be a default constructible, trivially destructible and with a size of at most 64bit"
+        );
+        if (std::is_same<T, string>::value) {
+                info.prev_data = 0;
+        } else {
+                new (&info.prev_data) T{};
+        }
         info.update_delay = update_delay;
         info.update_timeout = 0.0;
         info.isChangedFunction = &multiplayerReplicationFunctions<T>::isChanged;

--- a/src/multiplayer.h
+++ b/src/multiplayer.h
@@ -49,14 +49,6 @@ template <typename T> struct multiplayerReplicationFunctions
 {
     static bool isChanged(void* data, void* prev_data_ptr)
     {
-        if ((data == nullptr) != (prev_data_ptr == nullptr)) {
-            return false;
-        }
-
-        if (data == nullptr) {
-            return true;
-        }
-
         T* ptr = (T*)data;
         T* prev_data = (T*)prev_data_ptr;
         if (*ptr != *prev_data)

--- a/src/multiplayer.h
+++ b/src/multiplayer.h
@@ -49,6 +49,14 @@ template <typename T> struct multiplayerReplicationFunctions
 {
     static bool isChanged(void* data, void* prev_data_ptr)
     {
+        if ((data == nullptr) != (prev_data_ptr == nullptr)) {
+            return false;
+        }
+
+        if (data == nullptr) {
+            return true;
+        }
+
         T* ptr = (T*)data;
         T* prev_data = (T*)prev_data_ptr;
         if (*ptr != *prev_data)
@@ -137,7 +145,7 @@ class MultiplayerObject : public virtual PObject
         const char* name;
 #endif
         void* ptr;
-        int64_t prev_data;
+        void* prev_data;
         float update_delay;
         float update_timeout;
 
@@ -171,7 +179,7 @@ public:
         info.name = name;
 #endif
         info.ptr = member;
-        info.prev_data = -1;
+        info.prev_data = nullptr;
         info.update_delay = update_delay;
         info.update_timeout = 0.0;
         info.isChangedFunction = &multiplayerReplicationFunctions<T>::isChanged;
@@ -195,7 +203,7 @@ public:
         info.name = name;
 #endif
         info.ptr = member;
-        info.prev_data = (int64_t) new std::vector<T>;
+        info.prev_data = new std::vector<T>;
         info.update_delay = update_delay;
         info.update_timeout = 0.0;
         info.isChangedFunction = &multiplayerReplicationFunctions<T>::isChangedVector;

--- a/src/multiplayer.h
+++ b/src/multiplayer.h
@@ -145,7 +145,7 @@ class MultiplayerObject : public virtual PObject
         const char* name;
 #endif
         void* ptr;
-        void* prev_data;
+        uint64_t prev_data;
         float update_delay;
         float update_timeout;
 
@@ -179,7 +179,7 @@ public:
         info.name = name;
 #endif
         info.ptr = member;
-        info.prev_data = nullptr;
+        info.prev_data = reinterpret_cast<std::uint64_t>(nullptr);
         info.update_delay = update_delay;
         info.update_timeout = 0.0;
         info.isChangedFunction = &multiplayerReplicationFunctions<T>::isChanged;
@@ -203,7 +203,7 @@ public:
         info.name = name;
 #endif
         info.ptr = member;
-        info.prev_data = new std::vector<T>;
+        info.prev_data = reinterpret_cast<std::uint64_t>(new std::vector<T>);
         info.update_delay = update_delay;
         info.update_timeout = 0.0;
         info.isChangedFunction = &multiplayerReplicationFunctions<T>::isChangedVector;


### PR DESCRIPTION
Tried running EmptyEpsilon with UBSan, which showed some undefined behaviors.

I would really like some feedback, because I am not sure of the intended behavior in some cases. For instance, `GrisuRound` caused a buffer overflow, but if it is correct to stop with the tenth byte or something different should be performed.

Another non-trivial refactor involves `prev_data`, which could be casted to a pointer and then deferenced even if pointing to bogus address. I changed the data type to a pointer (using a `int64_t` to store a pointer is not the best thing to do) and I added a couple of validity checks, but I am not sure if some sort of re-assignment of `prev_data` should be performed.

The hash type has been changed to correctly cast the pointer to a numeric type and, at the same type, to an unsigned type in order to avoid UBs from integer overflow.