### PR TITLE
Don't buffer logs on Win32

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -61,4 +61,9 @@ void Logging::setLogLevel(ELogLevel level)
 void Logging::setLogFile(string filename)
 {
     log_stream = fopen(filename.c_str(), "wt");
+    #ifdef __WIN32__
+    // win32 doesn't support line buffering. #1042
+    // Instead, don't buffer logging at all on Windows.
+    setvbuf(log_stream, NULL, _IONBF, 0);
+    #endif//__WIN32__
 }


### PR DESCRIPTION
Fixes daid/EmptyEpsilon#1042 on Windows.

Win32 doesn't support line buffering (`_IOLBF`) on streams:
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf?view=vs-2019#remarks

Ensuring useful log lines are written on a crash is much more
difficult without line buffering. Arbitrary buffer sizes will still
cut off log lines unless they're so small that the performance
difference compared to not buffering isn't much.

Might consider enabling or disabling logging via an option or command-line flag.