### PR TITLE
push an explicit nil to Lua when argument can not be converted

### DIFF
--- a/src/scriptInterface.h
+++ b/src/scriptInterface.h
@@ -59,28 +59,16 @@ private:
     int pushArgs(lua_State* L, ARG arg, ARGS... args)
     {
         int headItemsPushedToStack = pushArgs(L, arg);
-        if (headItemsPushedToStack > 0) 
-        {
-            int tailItemsPushedToStack = pushArgs(L, args...);
-            if (tailItemsPushedToStack >= 0) 
-            {
-                return headItemsPushedToStack + tailItemsPushedToStack;
-            } else {
-                // roll back items pushed to lua stack, because an error occured
-                lua_pop(L, headItemsPushedToStack);
-                return -1;
-            }
-        } else {
-            return -1;
-        }
+        int tailItemsPushedToStack = pushArgs(L, args...);
+        return headItemsPushedToStack + tailItemsPushedToStack;
     }
     template<typename T>
     int pushArgs(lua_State* L, T thing)
     {
         if (!convert<T>::returnType(L, thing))
         {
-            LOG(ERROR) << "Failed to find class for object";
-            return -1;
+            // nothing was pushed on the stack. Push nil explicitly to maintain argument positions
+            lua_pushnil(L);
         }
         return 1;
     }


### PR DESCRIPTION
Pushing a `nullptr` as Lua script argument lead to the error

````
[ERROR] Failed to find class for object
````

Now, `nil` is explicitly pushed in such a case.

I also removed the conditions in `int pushArgs(lua_State* L, ARG arg, ARGS... args)`, because with the change there is no case where `pushArgs` returns something smaller than `0`.

---

I also considered handling the `nullptr` here

https://github.com/daid/SeriousProton/blob/93b465c3924a54acd590a578fcbfbd0b64027cd8/src/scriptInterfaceMagic.h#L126-L130

But I think this would have more undesired side effects in existing scripts, because lists of objects would start to contain `nil`.