### PR TITLE
Display more data for leak checking

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -163,10 +163,25 @@ void Engine::handleEvent(sf::Event& event)
     if ((event.type == sf::Event::KeyPressed) && (event.key.code == sf::Keyboard::L))
     {
         int n = 0;
-        printf("---------------------\n");
+        printf("------------------------\n");
+        std::unordered_map<string,int> totals;
         for(PObject* obj = DEBUG_PobjListStart; obj; obj = obj->DEBUG_PobjListNext)
+        {
             printf("%c%4d: %4d: %s\n", obj->isDestroyed() ? '>' : ' ', n++, obj->getRefCount(), typeid(*obj).name());
-        printf("---------------------\n");
+            if (!obj->isDestroyed())
+            {
+                totals[typeid(*obj).name()]=totals[typeid(*obj).name()]+1;
+            }
+        }
+        printf("--non-destroyed totals--\n");
+        int grand_total=0;
+        for (auto entry : totals)
+        {
+            printf("%4d %s\n", entry.second, entry.first.c_str());
+            grand_total+=entry.second;
+        }
+        printf("%4d %s\n",grand_total,"All PObjects");
+        printf("------------------------\n");
     }
 #endif
     InputHandler::handleEvent(event);


### PR DESCRIPTION
the above code was useful in trying to understand resource leaks, for both the state_logger and scienceDatabases, it may be of use to others

```
an example of output is

------------------------                
    0:    3: 8MainMenu                  
    1:    2: 18HardwareController       
<<<nearly 300 lines removed to display here>>>>
  299:    1: 25DirectoryResourceProvider
  300:    1: 25DirectoryResourceProvider
--non-destroyed totals--
   1 13WindowManager
   1 13MouseRenderer
   1 13DebugRenderer
   1 10HttpServer
   2 18FileResourceStream
 126 9ModelData
 144 12ShipTemplate
  10 11FactionInfo
   1 20NetworkAudioRecorder
   1 18HardwareController
   3 20PackResourceProvider
   9 25DirectoryResourceProvider
   1 8MainMenu
 301 All PObjects
------------------------
```