### PR TITLE
Fire TextEvents if KeyEvent isn't fired due to an unknown SFML key code

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -111,6 +111,11 @@ void InputHandler::handleEvent(sf::Event& event)
             fireKeyEvent(last_key_press, event.text.unicode);
             last_key_press.code = sf::Keyboard::Unknown;
         }
+        else
+        {
+            // No relevant code for a KeyEvent, so pass the TextEvent instead.
+            fireTextEvent(event.text, event.text.unicode);
+        }
     }
     else if (event.type == sf::Event::MouseWheelMoved)
         mouse_wheel_delta += event.mouseWheel.delta;
@@ -236,6 +241,14 @@ void InputHandler::fireKeyEvent(sf::Event::KeyEvent key, int unicode)
     foreach(InputEventHandler, e, input_event_handlers)
     {
         e->handleKeyPress(key, unicode);
+    }
+}
+
+void InputHandler::fireTextEvent(sf::Event::TextEvent text, int unicode)
+{
+    for(auto e : input_event_handlers)
+    {
+        e->handleTextEntered(text, unicode);
     }
 }
 

--- a/src/input.h
+++ b/src/input.h
@@ -11,6 +11,7 @@ public:
     virtual ~InputEventHandler();
     
     virtual void handleKeyPress(sf::Event::KeyEvent key, int unicode) = 0;
+    virtual void handleTextEntered(sf::Event::TextEvent text, int unicode) = 0;
 protected:
 private:
 };
@@ -80,6 +81,7 @@ private:
     static void handleEvent(sf::Event& event);
     
     static void fireKeyEvent(sf::Event::KeyEvent key, int unicode);
+    static void fireTextEvent(sf::Event::TextEvent text, int unicode);
     static sf::Vector2f realWindowPosToVirtual(sf::Vector2i position);
     static sf::Vector2i virtualWindowPosToReal(sf::Vector2f position);
 


### PR DESCRIPTION
Attempt to workaround https://github.com/SFML/SFML/issues/7, blocking use of the <kbd>-</kbd> key in macOS.