### PR TITLE
Work around SFML limitation for macOS hyphen

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -106,10 +106,22 @@ void InputHandler::handleEvent(sf::Event& event)
 	}
     else if (event.type == sf::Event::TextEntered && event.text.unicode > 31 && event.text.unicode < 128)
     {
+        if (event.text.unicode == 45)
+        {
+            // If a key has a Unicode value but SFML won't
+            // give it the right code, fire it manually.
+            // "-" on macOS returns unicode 45. SFML/SFML#7
+            last_key_press.code = sf::Keyboard::Hyphen;
+        }
+
         if (last_key_press.code != sf::Keyboard::Unknown)
         {
             fireKeyEvent(last_key_press, event.text.unicode);
             last_key_press.code = sf::Keyboard::Unknown;
+        }
+        else
+        {
+            LOG(DEBUG) << "Key passed valid UTF-32 value, but SFML has no keycode for it: " << event.text.unicode;
         }
     }
     else if (event.type == sf::Event::MouseWheelMoved)


### PR DESCRIPTION
SFML leaves valid keys unmapped on some macOS keyboard locales.
Since we're passing all TextEntered events to fireKeyEvent anyway,
we can work around this by always mapping the appropriate SFML Key
based on returned UTF-32 value, instead of relying on SFML to map
the hardware virtualCode/usageCode correctly.

See SFML/SFML#7, SFML/SFML#450, SFML/SFML#974, SFML/SFML#1013

Details in https://github.com/SFML/SFML/blob/498d7ee79c700bba767ca42f68ced8ca116b5ada/src/SFML/Window/OSX/HIDInputManager.mm#L279-L298