### PR TITLE
Revert #48 for Clang

### DIFF
--- a/src/dtoa/dtoa_milo.h
+++ b/src/dtoa/dtoa_milo.h
@@ -292,7 +292,12 @@ inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buff
 
 	// kappa = 0
 	assert(*len >= 0);
+#ifdef __clang__
+  // Buffer bounds check in PR #48 breaks output in Clang. See issue #54.
+  for (;;) {
+#else
 	for (; static_cast<std::size_t>(*len) < sizeof(buffer);) {
+#endif
 		p2 *= 10;
 		delta *= 10;
 		char d = static_cast<char>(p2 >> -one.e);


### PR DESCRIPTION
When compiling with Clang, don't check the buffer bounds when
generating digits in dtoa_milo. This somehow breaks decimal
placement in the output, but only under Clang. (#54)

Upstream reference: https://github.com/miloyip/dtoa-benchmark/blob/bf1fb58ade01658c908a498679e47f0b4e89aff7/src/milo/dtoa_milo.h#L276