### PR TITLE
Implement Mac clipboard copy/paste

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -30,24 +30,28 @@ string Clipboard::readClipboard()
     return ret;
 #endif//_WIN32
 #if defined(__linux__) || defined(__APPLE__)
-#ifdef __linux__
-    FILE* pipe = popen("/usr/bin/xclip -o -selection clipboard", "r");
-#endif
 #ifdef __APPLE__
-    FILE* pipe = popen("/usr/bin/pbpaste", "r");
+    const char* cmd = "/usr/bin/pbpaste 2>&1";
+#else
+    const char* cmd = "/usr/bin/xclip -o -selection clipboard";
 #endif
+    FILE* pipe = popen(cmd, "r");
+
     if (!pipe)
     {
-        LOG(WARNING) << "Failed to execute command for clipboard access";
+        LOG(WARNING) << "Failed to execute " << cmd << " for clipboard access";
         return "";
     }
+
     char buffer[1024];
     std::string result = "";
+
     while (!feof(pipe))
     {
         if (fgets(buffer, 1024, pipe) != NULL)
             result += buffer;
     }
+
     pclose(pipe);
     return result;
 #endif//__linux__ || __APPLE__
@@ -84,17 +88,19 @@ void Clipboard::setClipboard(string value)
     CloseClipboard();
 #endif//_WIN32
 #if defined(__linux__) || defined(__APPLE__)
-#ifdef __linux__
-    FILE* pipe = popen("/usr/bin/xclip -i -selection clipboard -silent", "we");
-#endif
 #ifdef __APPLE__
-    FILE* pipe = popen("/usr/bin/pbcopy", "w");
+    const char* cmd = "/usr/bin/pbcopy > /dev/null 2>&1";
+#else
+    const char* cmd = "/usr/bin/xclip -i -selection clipboard -silent";
 #endif
+    FILE* pipe = popen(cmd, "w");
+
     if (!pipe)
     {
-        LOG(WARNING) << "Failed to execute command for clipboard access";
+        LOG(WARNING) << "Failed to execute " << cmd << " for clipboard access";
         return;
     }
+
     fwrite(value.c_str(), value.size(), 1, pipe);
     pclose(pipe);
 #endif//__linux__ || __APPLE__

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -90,10 +90,12 @@ void Clipboard::setClipboard(string value)
 #if defined(__linux__) || defined(__APPLE__)
 #ifdef __APPLE__
     const char* cmd = "/usr/bin/pbcopy > /dev/null 2>&1";
+    const char* mode = "w";
 #else
     const char* cmd = "/usr/bin/xclip -i -selection clipboard -silent";
+    const char* mode = "we";
 #endif
-    FILE* pipe = popen(cmd, "w");
+    FILE* pipe = popen(cmd, mode);
 
     if (!pipe)
     {

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -29,11 +29,16 @@ string Clipboard::readClipboard()
     CloseClipboard();
     return ret;
 #endif//_WIN32
+#if defined(__linux__) || defined(__APPLE__)
 #ifdef __linux__
     FILE* pipe = popen("/usr/bin/xclip -o -selection clipboard", "r");
+#endif
+#ifdef __APPLE__
+    FILE* pipe = popen("/usr/bin/pbpaste", "r");
+#endif
     if (!pipe)
     {
-        LOG(WARNING) << "Failed to execute /usr/bin/xclip for clipboard access";
+        LOG(WARNING) << "Failed to execute command for clipboard access";
         return "";
     }
     char buffer[1024];
@@ -45,8 +50,7 @@ string Clipboard::readClipboard()
     }
     pclose(pipe);
     return result;
-#endif
-
+#endif//__linux__ || __APPLE__
     return "";
 }
 
@@ -79,14 +83,19 @@ void Clipboard::setClipboard(string value)
 
     CloseClipboard();
 #endif//_WIN32
+#if defined(__linux__) || defined(__APPLE__)
 #ifdef __linux__
     FILE* pipe = popen("/usr/bin/xclip -i -selection clipboard -silent", "we");
+#endif
+#ifdef __APPLE__
+    FILE* pipe = popen("/usr/bin/pbcopy", "w");
+#endif
     if (!pipe)
     {
-        LOG(WARNING) << "Failed to execute /usr/bin/xclip for clipboard access";
+        LOG(WARNING) << "Failed to execute command for clipboard access";
         return;
     }
     fwrite(value.c_str(), value.size(), 1, pipe);
     pclose(pipe);
-#endif
+#endif//__linux__ || __APPLE__
 }


### PR DESCRIPTION
Use `pbcopy` and `pbpaste` parallel to the `xclip` implementation for Linux.

Tested by copying scenario data from a Battlefield scenario with the Huge variation from the GM screen, resulting in about 150kb, and pasting it into a ship's description in the tweak menu.