### PR TITLE
Cmake 3.7 - cont'd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,122 +1,115 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(SeriousProton)
+cmake_minimum_required(VERSION 3.7)
+project(SeriousProton LANGUAGES CXX)
 set(CMAKE_MODULE_PATH
-	${CMAKE_SOURCE_DIR}/cmake/
-	${CMAKE_MODULE_PATH}
+    ${CMAKE_SOURCE_DIR}/cmake/
+    ${CMAKE_MODULE_PATH}
 )
 
 #---------------------------------File lists-----------------------------------
 set(source_files_relative #All SeriousProton's objects to compile
-	src/clipboard.cpp
-	src/collisionable.cpp
-	src/engine.cpp
-	src/event.cpp
-	src/fixedSocket.cpp
-	src/gameEntity.cpp
-	src/httpServer.cpp
-	src/input.cpp
-	src/logging.cpp
-	src/multiplayer.cpp
-	src/multiplayer_client.cpp
-	src/multiplayer_server.cpp
-	src/multiplayer_server_scanner.cpp
-	src/networkAudioStream.cpp
-	src/networkRecorder.cpp
-	src/PlayerController.cpp
-	src/postProcessManager.cpp
-	src/random.cpp
-	src/Renderable.cpp
-	src/resources.cpp
-	src/scriptInterface.cpp
-	src/scriptInterfaceMagic.cpp
-	src/shaderManager.cpp
-	src/soundManager.cpp
-	src/stringImproved.cpp
-	src/textureManager.cpp
-	src/tween.cpp
-	src/Updatable.cpp
-	src/windowManager.cpp
+    src/clipboard.cpp
+    src/collisionable.cpp
+    src/engine.cpp
+    src/event.cpp
+    src/fixedSocket.cpp
+    src/gameEntity.cpp
+    src/httpServer.cpp
+    src/input.cpp
+    src/logging.cpp
+    src/multiplayer.cpp
+    src/multiplayer_client.cpp
+    src/multiplayer_server.cpp
+    src/multiplayer_server_scanner.cpp
+    src/networkAudioStream.cpp
+    src/networkRecorder.cpp
+    src/PlayerController.cpp
+    src/postProcessManager.cpp
+    src/random.cpp
+    src/Renderable.cpp
+    src/resources.cpp
+    src/scriptInterface.cpp
+    src/scriptInterfaceMagic.cpp
+    src/shaderManager.cpp
+    src/soundManager.cpp
+    src/stringImproved.cpp
+    src/textureManager.cpp
+    src/tween.cpp
+    src/Updatable.cpp
+    src/windowManager.cpp
 )
 set(source_files "")
 foreach(source_file_relative ${source_files_relative})
-	list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
+    list(APPEND source_files ${CMAKE_SOURCE_DIR}/${source_file_relative})
 endforeach()
 
-set(seriousproton_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/src/)
-
-include_directories(
-	${CMAKE_CURRENT_BINARY_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/src
-	${CMAKE_CURRENT_SOURCE_DIR}/src/libopus/include
-)
+set(seriousproton_include_dir ${CMAKE_SOURCE_DIR}/src/)
 
 #----------------------------------Compiling-----------------------------------
-if(CMAKE_VERSION VERSION_LESS "3.1")
-	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-		set(CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")
-	endif()
-else()
-	set(CMAKE_CXX_STANDARD 11)
-endif()
+set(CMAKE_CXX_STANDARD 11)
 
 add_library(seriousproton STATIC ${source_files})
+
+target_include_directories(seriousproton
+    PUBLIC    
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/libopus/include>
+)
 target_compile_definitions(seriousproton
-	PUBLIC
-		SFML_NO_DEPRECATED_WARNINGS # SFML 2.5 gives deprication warnings on a few functions we use. But we maintain 2.3 compatibility, so ignore those warnings.
-		$<$<BOOL:${WIN32}>:NOMINMAX>
+    PUBLIC
+        SFML_NO_DEPRECATED_WARNINGS # SFML 2.5 gives deprication warnings on a few functions we use. But we maintain 2.3 compatibility, so ignore those warnings.
+        $<$<BOOL:${WIN32}>:NOMINMAX>
 )
 
 #--------------------------------Dependencies----------------------------------
 include(ExternalProject)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/Box2D)
-add_dependencies(seriousproton box2d)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/lua)
-add_dependencies(seriousproton lua)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/GL)
-add_dependencies(seriousproton glew)
 
 find_package(SFML 2.3 COMPONENTS system audio network window graphics)
 if(NOT ${SFML_FOUND})
-	message(STATUS "Couldn't find SFML. Building it from scratch. Installing to ${CMAKE_INSTALL_PREFIX}")
-	ExternalProject_Add(SFML
-		GIT_REPOSITORY https://github.com/SFML/SFML.git
-		GIT_TAG 2.4.2 #Always build with this tag, so we're sure it is stable.
-		CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBUILD_SHARED_LIBS=OFF
-	)
-	set(SFML_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include) #Otherwise this is filled by FindSFML.cmake.
-	set(SFML_LIBRARIES
-		${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-audio${CMAKE_STATIC_LIBRARY_SUFFIX}
-		${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-graphics${CMAKE_STATIC_LIBRARY_SUFFIX}
-		${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-network${CMAKE_STATIC_LIBRARY_SUFFIX}
-		${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-system${CMAKE_STATIC_LIBRARY_SUFFIX}
-		${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-window${CMAKE_STATIC_LIBRARY_SUFFIX}
-	)
-	add_dependencies(seriousproton SFML)
+    message(STATUS "Couldn't find SFML. Building it from scratch. Installing to ${CMAKE_INSTALL_PREFIX}")
+    ExternalProject_Add(SFML
+        GIT_REPOSITORY https://github.com/SFML/SFML.git
+        GIT_TAG 2.4.2 #Always build with this tag, so we're sure it is stable.
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBUILD_SHARED_LIBS=OFF
+    )
+    set(SFML_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include) #Otherwise this is filled by FindSFML.cmake.
+    set(SFML_LIBRARIES
+        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-audio${CMAKE_STATIC_LIBRARY_SUFFIX}
+        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-graphics${CMAKE_STATIC_LIBRARY_SUFFIX}
+        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-network${CMAKE_STATIC_LIBRARY_SUFFIX}
+        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-system${CMAKE_STATIC_LIBRARY_SUFFIX}
+        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-window${CMAKE_STATIC_LIBRARY_SUFFIX}
+    )
+    add_dependencies(seriousproton SFML)
 endif()
-include_directories(${SFML_INCLUDE_DIR})
-target_link_libraries(seriousproton ${SFML_LIBRARIES})
+
+target_include_directories(seriousproton PUBLIC ${SFML_INCLUDE_DIR})
+target_link_libraries(seriousproton PUBLIC box2d lua glew ${SFML_LIBRARIES})
 
 #--------------------------------Installation----------------------------------
 install(
-	TARGETS seriousproton
-	EXPORT seriousproton
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib
+    TARGETS seriousproton
+    EXPORT seriousproton
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
 )
 install(
-	DIRECTORY ${seriousproton_include_dir}
-	DESTINATION include/seriousproton
-	FILES_MATCHING PATTERN "*.h"
+    DIRECTORY ${seriousproton_include_dir}
+    DESTINATION include/seriousproton
+    FILES_MATCHING PATTERN "*.h"
 )
 install(
-	DIRECTORY ${seriousproton_include_dir}
-	DESTINATION include/seriousproton
-	FILES_MATCHING PATTERN "*.hpp"
+    DIRECTORY ${seriousproton_include_dir}
+    DESTINATION include/seriousproton
+    FILES_MATCHING PATTERN "*.hpp"
 )
 install(
-	EXPORT seriousproton
-	DESTINATION share/seriousproton
+    EXPORT seriousproton
+    DESTINATION share/seriousproton
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,9 @@ if(ENABLE_CRASH_LOGGER)
             set(DISCORD_ARCH "32")
         endif()
 
-        set(DRMINGW_VERSION "0.9.3")
+        # 0.9.x seems to give a hard time to people on Win7.
+        # Sticking with 0.8 for that reason.
+        set(DRMINGW_VERSION "0.8.2")
         set(DRMINGW_BASENAME "drmingw-${DRMINGW_VERSION}-win${DRMINGW_ARCH}")
         set(DRMINGW_ROOT "${CMAKE_CURRENT_BINARY_DIR}/${DRMINGW_BASENAME}" CACHE PATH "Path to Dr. MinGW" FORCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,39 +11,34 @@ set(CMAKE_MODULE_PATH
 )
 
 # User-settings
-option(ENABLE_CRASH_LOGGER "Enable the Dr. MinGW crash logging facilities" OFF)
-
-if(MINGW)
-	set(DRMINGW_ROOT DRMINGW_ROOT-NOTFOUND CACHE PATH "Path to Dr. MinGW")
+if(WIN32)
+    option(ENABLE_CRASH_LOGGER "Enable the Dr. MinGW crash logging facilities" ON)
+    set(DRMINGW_ROOT DRMINGW_ROOT-NOTFOUND CACHE PATH "Path to Dr. MinGW")
 endif()
+
 # Preflight checks.
-
-
 message(STATUS "Crash Logger is " ${ENABLE_CRASH_LOGGER})
 
 if(ENABLE_CRASH_LOGGER)
     if(NOT DRMINGW_ROOT)
         message("Downloading Dr. MinGW")
-        set(DRMINGW_ROOT "${CMAKE_CURRENT_BINARY_DIR}/drmingw" CACHE PATH "Path to Dr. MinGW" FORCE)
-        
 
-        if(NOT EXISTS "${DRMINGW_ROOT}/include/exchndl.h")
-            set(DRMINGW_ZIP "${DRMINGW_ROOT}/drmingw.7z")
-            set(DRMINGW_ARCH "64")
-            if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
-                set(DISCORD_ARCH "32")
-            endif()
-            file(DOWNLOAD "https://github.com/jrfonseca/drmingw/releases/download/0.9.3/drmingw-0.9.3-win${DRMINGW_ARCH}.7z" "${DRMINGW_ZIP}" TIMEOUT 60 TLS_VERIFY ON)
-            execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf "${DRMINGW_ZIP}" WORKING_DIRECTORY "${DRMINGW_ROOT}")
+        set(DRMINGW_ARCH "64")
+        if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
+            set(DISCORD_ARCH "32")
+        endif()
+
+        set(DRMINGW_VERSION "0.9.3")
+        set(DRMINGW_BASENAME "drmingw-${DRMINGW_VERSION}-win${DRMINGW_ARCH}")
+        set(DRMINGW_ROOT "${CMAKE_CURRENT_BINARY_DIR}/${DRMINGW_BASENAME}" CACHE PATH "Path to Dr. MinGW" FORCE)
+
+        if(NOT EXISTS "${DRMINGW_ROOT}/bin/exchndl.dll")
+            set(DRMINGW_ZIP "${CMAKE_CURRENT_BINARY_DIR}/${DRMINGW_BASENAME}.7z")
+            
+            file(DOWNLOAD "https://github.com/jrfonseca/drmingw/releases/download/${DRMINGW_VERSION}/${DRMINGW_BASENAME}.7z" "${DRMINGW_ZIP}" TIMEOUT 60 TLS_VERIFY ON)
+            execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf "${DRMINGW_ZIP}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
         endif()
     endif()
-
-    add_library(drmingw SHARED IMPORTED)
-    set_target_properties(drmingw PROPERTIES
-        IMPORTED_LOCATION "${DRMINGW_ROOT}/bin/exchndl.dll"
-        IMPORTED_IMPLIB "${DRMINGW_ROOT}/lib/libexchndl.a"
-        INTERFACE_INCLUDE_DIRECTORIES "${DRMINGW_ROOT}/include/"
-    )
 endif()
 
 #--------------------------------Dependencies----------------------------------
@@ -146,29 +141,27 @@ endif()
 target_include_directories(seriousproton
     PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src;${CMAKE_CURRENT_SOURCE_DIR}/src/libopus/include;${SFML_INCLUDE_DIR}>"
-        "$<BUILD_INTERFACE:$<$<AND:$<BOOL:${WIN32}>,$<BOOL:${ENABLE_CRASH_LOGGER}>,$<BOOL:${MINGW}>>:${DRMINGW_ROOT}/include/>>"
 )
+
 target_compile_definitions(seriousproton
     PUBLIC
         SFML_NO_DEPRECATED_WARNINGS # SFML 2.5 gives deprication warnings on a few functions we use. But we maintain 2.3 compatibility, so ignore those warnings.
         $<$<BOOL:${MSVC}>:NOMINMAX>
         $<$<CONFIG:Debug>:DEBUG>
-        $<$<BOOL:${ENABLE_CRASH_LOGGER}:ENABLE_CRASH_LOGGER>
 )
 
 target_compile_options(seriousproton
     PUBLIC
         "$<$<AND:$<NOT:$<BOOL:${MSVC}>>,$<CONFIG:RelWithDebInfo>>:-g1>"
-	    "$<$<AND:$<NOT:$<BOOL:${MSVC}>>,$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Release>>>:${OPTIMIZER_FLAGS}>"
-	    "$<$<NOT:$<BOOL:${MSVC}>>:-Wall;-Werror=return-type>"
-	    "$<$<BOOL:${MSVC}>:/MP;/permissive->"
+        "$<$<AND:$<NOT:$<BOOL:${MSVC}>>,$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Release>>>:${OPTIMIZER_FLAGS}>"
+        "$<$<NOT:$<BOOL:${MSVC}>>:-Wall;-Werror=return-type>"
+        "$<$<BOOL:${MSVC}>:/MP;/permissive->"
 )
 
 target_link_libraries(seriousproton
     PUBLIC 
         box2d lua glew ${SFML_LIBRARIES}
         "$<$<BOOL:${WIN32}>:wsock32>"
-        "$<$<BOOL:${DRMINGW_ROOT}>:drmingw>"
 )
 
 #--------------------------------Installation----------------------------------
@@ -209,9 +202,9 @@ if(WIN32)
 
     if (MINGW)
         execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libstdc++-6.dll OUTPUT_VARIABLE MINGW_STDCPP_DLL OUTPUT_STRIP_TRAILING_WHITESPACE)
-	    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libgcc_s_sjlj-1.dll OUTPUT_VARIABLE MINGW_LIBGCC_DLL OUTPUT_STRIP_TRAILING_WHITESPACE)
-	    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libwinpthread-1.dll OUTPUT_VARIABLE MINGW_PTHREAD_DLL OUTPUT_STRIP_TRAILING_WHITESPACE)
-	    
+        execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libgcc_s_sjlj-1.dll OUTPUT_VARIABLE MINGW_LIBGCC_DLL OUTPUT_STRIP_TRAILING_WHITESPACE)
+        execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libwinpthread-1.dll OUTPUT_VARIABLE MINGW_PTHREAD_DLL OUTPUT_STRIP_TRAILING_WHITESPACE)
+        
         install(
             FILES
                 ${MINGW_STDCPP_DLL}
@@ -220,18 +213,18 @@ if(WIN32)
             DESTINATION .
             COMPONENT runtime
         )
+    endif()
 
-        if(ENABLE_CRASH_LOGGER)
-            install(
-                FILES
-                    ${DRMINGW_ROOT}/bin/dbghelp.dll
-                    ${DRMINGW_ROOT}/bin/exchndl.dll
-                    ${DRMINGW_ROOT}/bin/mgwhelp.dll
-                    ${DRMINGW_ROOT}/bin/symsrv.dll
-                    ${DRMINGW_ROOT}/bin/symsrv.yes
-                DESTINATION .
-                COMPONENT runtime
-            )
-        endif()
+    if(ENABLE_CRASH_LOGGER)
+        install(
+            FILES
+            ${DRMINGW_ROOT}/bin/dbghelp.dll
+            ${DRMINGW_ROOT}/bin/exchndl.dll
+            ${DRMINGW_ROOT}/bin/mgwhelp.dll
+            ${DRMINGW_ROOT}/bin/symsrv.dll
+            ${DRMINGW_ROOT}/bin/symsrv.yes
+            DESTINATION .
+            COMPONENT runtime
+        )
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ if(NOT ${SFML_FOUND})
     add_dependencies(seriousproton SFML)
 endif()
 
-target_include_directories(seriousproton PUBLIC ${SFML_INCLUDE_DIR})
+target_include_directories(seriousproton PUBLIC $<BUILD_INTERFACE:${SFML_INCLUDE_DIR}>)
 target_link_libraries(seriousproton PUBLIC box2d lua glew ${SFML_LIBRARIES})
 
 #--------------------------------Installation----------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,5 @@
-cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 project(SeriousProton LANGUAGES CXX)
-
-# Setup
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/cmake/
@@ -11,6 +7,8 @@ set(CMAKE_MODULE_PATH
 )
 
 # User-settings
+option(SERIOUSPROTON_WITH_JSON "Use json library." OFF)
+
 if(WIN32)
     option(ENABLE_CRASH_LOGGER "Enable the Dr. MinGW crash logging facilities" OFF)
     set(DRMINGW_ROOT DRMINGW_ROOT-NOTFOUND CACHE PATH "Path to Dr. MinGW")
@@ -81,6 +79,11 @@ endif()
 add_subdirectory(src/Box2D)
 add_subdirectory(src/lua)
 add_subdirectory(src/GL)
+add_subdirectory(src/libopus)
+
+if(SERIOUSPROTON_WITH_JSON)
+    add_subdirectory(src/json11)
+endif()
 
 #---------------------------------File lists-----------------------------------
 set(source_files #All SeriousProton's objects to compile
@@ -135,6 +138,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 add_library(seriousproton STATIC ${source_files})
+target_compile_features(seriousproton PUBLIC cxx_std_17)
 
 if(NOT ${SFML_FOUND})
     add_dependencies(seriousproton SFML)
@@ -142,7 +146,7 @@ endif()
 
 target_include_directories(seriousproton
     PUBLIC
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src;${CMAKE_CURRENT_SOURCE_DIR}/src/libopus/include;${SFML_INCLUDE_DIR}>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src;${SFML_INCLUDE_DIR}>"
 )
 
 target_compile_definitions(seriousproton
@@ -150,6 +154,8 @@ target_compile_definitions(seriousproton
         SFML_NO_DEPRECATED_WARNINGS # SFML 2.5 gives deprication warnings on a few functions we use. But we maintain 2.3 compatibility, so ignore those warnings.
         $<$<BOOL:${MSVC}>:NOMINMAX>
         $<$<CONFIG:Debug>:DEBUG>
+        # Windows: Backwards compatibility with Win7 SP1: https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt
+        $<$<BOOL:${WIN32}>:WINVER=0x0601;_WIN32_WINNT=0x0601>
 )
 
 target_compile_options(seriousproton
@@ -164,6 +170,9 @@ target_link_libraries(seriousproton
     PUBLIC 
         box2d lua glew ${SFML_LIBRARIES}
         "$<$<BOOL:${WIN32}>:wsock32>"
+    PRIVATE $<BUILD_INTERFACE:opus>
+    INTERFACE
+        $<BUILD_INTERFACE:$<$<BOOL:${SERIOUSPROTON_WITH_JSON}>:json11>>
 )
 
 #--------------------------------Installation----------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH
 
 # User-settings
 if(WIN32)
-    option(ENABLE_CRASH_LOGGER "Enable the Dr. MinGW crash logging facilities" ON)
+    option(ENABLE_CRASH_LOGGER "Enable the Dr. MinGW crash logging facilities" OFF)
     set(DRMINGW_ROOT DRMINGW_ROOT-NOTFOUND CACHE PATH "Path to Dr. MinGW")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,92 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
 project(SeriousProton LANGUAGES CXX)
+
+# Setup
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 set(CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/cmake/
     ${CMAKE_MODULE_PATH}
 )
 
+# User-settings
+option(ENABLE_CRASH_LOGGER "Enable the Dr. MinGW crash logging facilities" OFF)
+
+if(MINGW)
+	set(DRMINGW_ROOT DRMINGW_ROOT-NOTFOUND CACHE PATH "Path to Dr. MinGW")
+endif()
+# Preflight checks.
+
+
+message(STATUS "Crash Logger is " ${ENABLE_CRASH_LOGGER})
+
+if(ENABLE_CRASH_LOGGER)
+    if(NOT DRMINGW_ROOT)
+        message("Downloading Dr. MinGW")
+        set(DRMINGW_ROOT "${CMAKE_CURRENT_BINARY_DIR}/drmingw" CACHE PATH "Path to Dr. MinGW" FORCE)
+        
+
+        if(NOT EXISTS "${DRMINGW_ROOT}/include/exchndl.h")
+            set(DRMINGW_ZIP "${DRMINGW_ROOT}/drmingw.7z")
+            set(DRMINGW_ARCH "64")
+            if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
+                set(DISCORD_ARCH "32")
+            endif()
+            file(DOWNLOAD "https://github.com/jrfonseca/drmingw/releases/download/0.9.3/drmingw-0.9.3-win${DRMINGW_ARCH}.7z" "${DRMINGW_ZIP}" TIMEOUT 60 TLS_VERIFY ON)
+            execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf "${DRMINGW_ZIP}" WORKING_DIRECTORY "${DRMINGW_ROOT}")
+        endif()
+    endif()
+
+    add_library(drmingw SHARED IMPORTED)
+    set_target_properties(drmingw PROPERTIES
+        IMPORTED_LOCATION "${DRMINGW_ROOT}/bin/exchndl.dll"
+        IMPORTED_IMPLIB "${DRMINGW_ROOT}/lib/libexchndl.a"
+        INTERFACE_INCLUDE_DIRECTORIES "${DRMINGW_ROOT}/include/"
+    )
+endif()
+
+#--------------------------------Dependencies----------------------------------
+find_package(SFML 2.4 COMPONENTS system audio network window graphics)
+if(NOT ${SFML_FOUND})
+    message(STATUS "Couldn't find SFML. Building it from scratch.")
+    
+    set(SFML_ROOT "${CMAKE_CURRENT_BINARY_DIR}/SFML-prefix")
+
+    include(ExternalProject)
+
+    ExternalProject_Add(SFML
+        GIT_REPOSITORY https://github.com/SFML/SFML.git
+        GIT_TAG 2.5.1 #Always build with this tag, so we're sure it is stable.
+        GIT_SHALLOW 1 # Don't get the entire history
+        CMAKE_ARGS -DBUILD_SHARED_LIBS=$<BOOL:${WIN32}> -DCMAKE_INSTALL_PREFIX=${SFML_ROOT}
+    )
+
+    set(SFML_INCLUDE_DIR "${SFML_ROOT}/include") #Otherwise this is filled by FindSFML.cmake.
+
+    set(_SFML_LIB_PREFIX STATIC)
+    set(_SFML_LIB_SUFFIX STATIC)
+
+    if(WIN32)
+        set(_SFML_LIB_PREFIX SHARED)
+        set(_SFML_LIB_SUFFIX LINK)
+    endif()
+
+    set(SFML_LIBRARIES
+        "${SFML_ROOT}/lib/${CMAKE_${_SFML_LIB_TYPE}_LIBRARY_PREFIX}sfml-audio${CMAKE_${_SFML_LIB_SUFFIX}_LIBRARY_SUFFIX}"
+        "${SFML_ROOT}/lib/${CMAKE_${_SFML_LIB_TYPE}_LIBRARY_PREFIX}sfml-graphics${CMAKE_${_SFML_LIB_SUFFIX}_LIBRARY_SUFFIX}"
+        "${SFML_ROOT}/lib/${CMAKE_${_SFML_LIB_TYPE}_LIBRARY_PREFIX}sfml-network${CMAKE_${_SFML_LIB_SUFFIX}_LIBRARY_SUFFIX}"
+        "${SFML_ROOT}/lib/${CMAKE_${_SFML_LIB_TYPE}_LIBRARY_PREFIX}sfml-system${CMAKE_${_SFML_LIB_SUFFIX}_LIBRARY_SUFFIX}"
+        "${SFML_ROOT}/lib/${CMAKE_${_SFML_LIB_TYPE}_LIBRARY_PREFIX}sfml-window${CMAKE_${_SFML_LIB_SUFFIX}_LIBRARY_SUFFIX}"
+    )
+endif()
+
+add_subdirectory(src/Box2D)
+add_subdirectory(src/lua)
+add_subdirectory(src/GL)
+
 #---------------------------------File lists-----------------------------------
-set(source_files_relative #All SeriousProton's objects to compile
+set(source_files #All SeriousProton's objects to compile
     src/clipboard.cpp
     src/collisionable.cpp
     src/engine.cpp
@@ -14,14 +94,17 @@ set(source_files_relative #All SeriousProton's objects to compile
     src/fixedSocket.cpp
     src/gameEntity.cpp
     src/httpServer.cpp
+    src/i18n.cpp
     src/input.cpp
     src/logging.cpp
     src/multiplayer.cpp
     src/multiplayer_client.cpp
+    src/multiplayer_proxy.cpp
     src/multiplayer_server.cpp
     src/multiplayer_server_scanner.cpp
     src/networkAudioStream.cpp
     src/networkRecorder.cpp
+    src/P.cpp
     src/PlayerController.cpp
     src/postProcessManager.cpp
     src/random.cpp
@@ -37,60 +120,56 @@ set(source_files_relative #All SeriousProton's objects to compile
     src/Updatable.cpp
     src/windowManager.cpp
 )
-set(source_files "")
-foreach(source_file_relative ${source_files_relative})
-    list(APPEND source_files ${CMAKE_SOURCE_DIR}/${source_file_relative})
-endforeach()
-
-set(seriousproton_include_dir ${CMAKE_SOURCE_DIR}/src/)
 
 #----------------------------------Compiling-----------------------------------
-set(CMAKE_CXX_STANDARD 11)
+
+
+# Set our optimization flags.
+set(OPTIMIZER_FLAGS)
+if(CMAKE_COMPILER_IS_GNUCC)
+    # On gcc, we want some general optimalizations that improve speed a lot.
+    set(OPTIMIZER_FLAGS ${OPTIMIZER_FLAGS} -O3 -flto -funsafe-math-optimizations)
+
+    # If we are compiling for a rasberry pi, we want to aggressively optimize for the CPU we are running on.
+    # Note that this check only works if we are compiling directly on the pi, as it is a dirty way of checkif if we are on the pi.
+    if(EXISTS /opt/vc/include/bcm_host.h OR COMPILE_FOR_PI)
+        set(OPTIMIZER_FLAGS ${OPTIMIZER_FLAGS} -mcpu=native -mfpu=neon-vfpv4 -mfloat-abi=hard)
+    endif()
+endif()
 
 add_library(seriousproton STATIC ${source_files})
 
+if(NOT ${SFML_FOUND})
+    add_dependencies(seriousproton SFML)
+endif()
+
 target_include_directories(seriousproton
-    PUBLIC    
-        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/libopus/include>
+    PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src;${CMAKE_CURRENT_SOURCE_DIR}/src/libopus/include;${SFML_INCLUDE_DIR}>"
+        "$<BUILD_INTERFACE:$<$<AND:$<BOOL:${WIN32}>,$<BOOL:${ENABLE_CRASH_LOGGER}>,$<BOOL:${MINGW}>>:${DRMINGW_ROOT}/include/>>"
 )
 target_compile_definitions(seriousproton
     PUBLIC
         SFML_NO_DEPRECATED_WARNINGS # SFML 2.5 gives deprication warnings on a few functions we use. But we maintain 2.3 compatibility, so ignore those warnings.
-        $<$<BOOL:${WIN32}>:NOMINMAX>
+        $<$<BOOL:${MSVC}>:NOMINMAX>
+        $<$<CONFIG:Debug>:DEBUG>
+        $<$<BOOL:${ENABLE_CRASH_LOGGER}:ENABLE_CRASH_LOGGER>
 )
 
-#--------------------------------Dependencies----------------------------------
-include(ExternalProject)
+target_compile_options(seriousproton
+    PUBLIC
+        "$<$<AND:$<NOT:$<BOOL:${MSVC}>>,$<CONFIG:RelWithDebInfo>>:-g1>"
+	    "$<$<AND:$<NOT:$<BOOL:${MSVC}>>,$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Release>>>:${OPTIMIZER_FLAGS}>"
+	    "$<$<NOT:$<BOOL:${MSVC}>>:-Wall;-Werror=return-type>"
+	    "$<$<BOOL:${MSVC}>:/MP;/permissive->"
+)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/Box2D)
-
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/lua)
-
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/GL)
-
-find_package(SFML 2.3 COMPONENTS system audio network window graphics)
-if(NOT ${SFML_FOUND})
-    message(STATUS "Couldn't find SFML. Building it from scratch. Installing to ${CMAKE_INSTALL_PREFIX}")
-    ExternalProject_Add(SFML
-        GIT_REPOSITORY https://github.com/SFML/SFML.git
-        GIT_TAG 2.4.2 #Always build with this tag, so we're sure it is stable.
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBUILD_SHARED_LIBS=OFF
-    )
-    set(SFML_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include) #Otherwise this is filled by FindSFML.cmake.
-    set(SFML_LIBRARIES
-        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-audio${CMAKE_STATIC_LIBRARY_SUFFIX}
-        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-graphics${CMAKE_STATIC_LIBRARY_SUFFIX}
-        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-network${CMAKE_STATIC_LIBRARY_SUFFIX}
-        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-system${CMAKE_STATIC_LIBRARY_SUFFIX}
-        ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sfml-window${CMAKE_STATIC_LIBRARY_SUFFIX}
-    )
-    add_dependencies(seriousproton SFML)
-endif()
-
-target_include_directories(seriousproton PUBLIC $<BUILD_INTERFACE:${SFML_INCLUDE_DIR}>)
-target_link_libraries(seriousproton PUBLIC box2d lua glew ${SFML_LIBRARIES})
+target_link_libraries(seriousproton
+    PUBLIC 
+        box2d lua glew ${SFML_LIBRARIES}
+        "$<$<BOOL:${WIN32}>:wsock32>"
+        "$<$<BOOL:${DRMINGW_ROOT}>:drmingw>"
+)
 
 #--------------------------------Installation----------------------------------
 install(
@@ -103,6 +182,7 @@ install(
     DIRECTORY ${seriousproton_include_dir}
     DESTINATION include/seriousproton
     FILES_MATCHING PATTERN "*.h"
+    
 )
 install(
     DIRECTORY ${seriousproton_include_dir}
@@ -113,3 +193,45 @@ install(
     EXPORT seriousproton
     DESTINATION share/seriousproton
 )
+
+if(WIN32)
+    install(
+        FILES
+            "${SFML_ROOT}/bin/OpenAL32.dll"
+            "${SFML_ROOT}/bin/sfml-audio-2.dll"
+            "${SFML_ROOT}/bin/sfml-graphics-2.dll"
+            "${SFML_ROOT}/bin/sfml-network-2.dll"
+            "${SFML_ROOT}/bin/sfml-system-2.dll"
+            "${SFML_ROOT}/bin/sfml-window-2.dll"
+        DESTINATION .
+        COMPONENT runtime
+    )
+
+    if (MINGW)
+        execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libstdc++-6.dll OUTPUT_VARIABLE MINGW_STDCPP_DLL OUTPUT_STRIP_TRAILING_WHITESPACE)
+	    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libgcc_s_sjlj-1.dll OUTPUT_VARIABLE MINGW_LIBGCC_DLL OUTPUT_STRIP_TRAILING_WHITESPACE)
+	    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libwinpthread-1.dll OUTPUT_VARIABLE MINGW_PTHREAD_DLL OUTPUT_STRIP_TRAILING_WHITESPACE)
+	    
+        install(
+            FILES
+                ${MINGW_STDCPP_DLL}
+                ${MINGW_LIBGCC_DLL}
+                ${MINGW_PTHREAD_DLL}
+            DESTINATION .
+            COMPONENT runtime
+        )
+
+        if(ENABLE_CRASH_LOGGER)
+            install(
+                FILES
+                    ${DRMINGW_ROOT}/bin/dbghelp.dll
+                    ${DRMINGW_ROOT}/bin/exchndl.dll
+                    ${DRMINGW_ROOT}/bin/mgwhelp.dll
+                    ${DRMINGW_ROOT}/bin/symsrv.dll
+                    ${DRMINGW_ROOT}/bin/symsrv.yes
+                DESTINATION .
+                COMPONENT runtime
+            )
+        endif()
+    endif()
+endif()

--- a/src/Box2D/CMakeLists.txt
+++ b/src/Box2D/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7)
 project(Box2D LANGUAGES CXX)
 
 #---------------------------------File lists-----------------------------------
-set(source_files_relative
+set(source_files
     Collision/b2BroadPhase.cpp
     Collision/b2CollideEdge.cpp
     Collision/b2CollideCircle.cpp
@@ -53,10 +53,6 @@ set(source_files_relative
 
     Rope/b2Rope.cpp
 )
-set(source_files "")
-foreach(source_file_relative ${source_files_relative})
-    list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
-endforeach()
 
 #----------------------------------Compiling-----------------------------------
 add_library(box2d STATIC ${source_files})

--- a/src/Box2D/CMakeLists.txt
+++ b/src/Box2D/CMakeLists.txt
@@ -1,84 +1,82 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(Box2D)
+cmake_minimum_required(VERSION 3.7)
+project(Box2D LANGUAGES CXX)
 
 #---------------------------------File lists-----------------------------------
 set(source_files_relative
-	Collision/b2BroadPhase.cpp
-	Collision/b2CollideEdge.cpp
-	Collision/b2CollideCircle.cpp
-	Collision/b2CollidePolygon.cpp
-	Collision/b2Collision.cpp
-	Collision/b2Distance.cpp
-	Collision/b2DynamicTree.cpp
-	Collision/b2TimeOfImpact.cpp
-	Collision/Shapes/b2ChainShape.cpp
-	Collision/Shapes/b2CircleShape.cpp
-	Collision/Shapes/b2EdgeShape.cpp
-	Collision/Shapes/b2PolygonShape.cpp
+    Collision/b2BroadPhase.cpp
+    Collision/b2CollideEdge.cpp
+    Collision/b2CollideCircle.cpp
+    Collision/b2CollidePolygon.cpp
+    Collision/b2Collision.cpp
+    Collision/b2Distance.cpp
+    Collision/b2DynamicTree.cpp
+    Collision/b2TimeOfImpact.cpp
+    Collision/Shapes/b2ChainShape.cpp
+    Collision/Shapes/b2CircleShape.cpp
+    Collision/Shapes/b2EdgeShape.cpp
+    Collision/Shapes/b2PolygonShape.cpp
 
-	Common/b2BlockAllocator.cpp
-	Common/b2Draw.cpp
-	Common/b2Math.cpp
-	Common/b2Settings.cpp
-	Common/b2StackAllocator.cpp
-	Common/b2Timer.cpp
+    Common/b2BlockAllocator.cpp
+    Common/b2Draw.cpp
+    Common/b2Math.cpp
+    Common/b2Settings.cpp
+    Common/b2StackAllocator.cpp
+    Common/b2Timer.cpp
 
-	Dynamics/b2Body.cpp
-	Dynamics/b2ContactManager.cpp
-	Dynamics/b2Fixture.cpp
-	Dynamics/b2Island.cpp
-	Dynamics/b2World.cpp
-	Dynamics/b2WorldCallbacks.cpp
-	Dynamics/Contacts/b2ChainAndCircleContact.cpp
-	Dynamics/Contacts/b2ChainAndPolygonContact.cpp
-	Dynamics/Contacts/b2CircleContact.cpp
-	Dynamics/Contacts/b2Contact.cpp
-	Dynamics/Contacts/b2ContactSolver.cpp
-	Dynamics/Contacts/b2EdgeAndCircleContact.cpp
-	Dynamics/Contacts/b2EdgeAndPolygonContact.cpp
-	Dynamics/Contacts/b2PolygonAndCircleContact.cpp
-	Dynamics/Contacts/b2PolygonContact.cpp
-	Dynamics/Joints/b2DistanceJoint.cpp
-	Dynamics/Joints/b2FrictionJoint.cpp
-	Dynamics/Joints/b2GearJoint.cpp
-	Dynamics/Joints/b2Joint.cpp
-	Dynamics/Joints/b2MotorJoint.cpp
-	Dynamics/Joints/b2MouseJoint.cpp
-	Dynamics/Joints/b2PrismaticJoint.cpp
-	Dynamics/Joints/b2PulleyJoint.cpp
-	Dynamics/Joints/b2RevoluteJoint.cpp
-	Dynamics/Joints/b2RopeJoint.cpp
-	Dynamics/Joints/b2WeldJoint.cpp
-	Dynamics/Joints/b2WheelJoint.cpp
+    Dynamics/b2Body.cpp
+    Dynamics/b2ContactManager.cpp
+    Dynamics/b2Fixture.cpp
+    Dynamics/b2Island.cpp
+    Dynamics/b2World.cpp
+    Dynamics/b2WorldCallbacks.cpp
+    Dynamics/Contacts/b2ChainAndCircleContact.cpp
+    Dynamics/Contacts/b2ChainAndPolygonContact.cpp
+    Dynamics/Contacts/b2CircleContact.cpp
+    Dynamics/Contacts/b2Contact.cpp
+    Dynamics/Contacts/b2ContactSolver.cpp
+    Dynamics/Contacts/b2EdgeAndCircleContact.cpp
+    Dynamics/Contacts/b2EdgeAndPolygonContact.cpp
+    Dynamics/Contacts/b2PolygonAndCircleContact.cpp
+    Dynamics/Contacts/b2PolygonContact.cpp
+    Dynamics/Joints/b2DistanceJoint.cpp
+    Dynamics/Joints/b2FrictionJoint.cpp
+    Dynamics/Joints/b2GearJoint.cpp
+    Dynamics/Joints/b2Joint.cpp
+    Dynamics/Joints/b2MotorJoint.cpp
+    Dynamics/Joints/b2MouseJoint.cpp
+    Dynamics/Joints/b2PrismaticJoint.cpp
+    Dynamics/Joints/b2PulleyJoint.cpp
+    Dynamics/Joints/b2RevoluteJoint.cpp
+    Dynamics/Joints/b2RopeJoint.cpp
+    Dynamics/Joints/b2WeldJoint.cpp
+    Dynamics/Joints/b2WheelJoint.cpp
 
-	Rope/b2Rope.cpp
+    Rope/b2Rope.cpp
 )
 set(source_files "")
 foreach(source_file_relative ${source_files_relative})
-	list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
+    list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
 endforeach()
-
-include_directories(
-	${CMAKE_CURRENT_BINARY_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/.. #Because the header files are requested starting from "Box2D/..."
-)
 
 #----------------------------------Compiling-----------------------------------
 add_library(box2d STATIC ${source_files})
 
+target_include_directories(box2d
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
+
 #--------------------------------Installation----------------------------------
 install(
-	TARGETS box2d
-	EXPORT box2d
-	DESTINATION lib
+    TARGETS box2d
+    EXPORT box2d
+    DESTINATION lib
 )
 install(
-	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	DESTINATION include
-	FILES_MATCHING PATTERN "*.h"
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.h"
 )
 install(
-	EXPORT box2d
-	DESTINATION share/box2d
+    EXPORT box2d
+    DESTINATION share/box2d
 )

--- a/src/GL/CMakeLists.txt
+++ b/src/GL/CMakeLists.txt
@@ -2,13 +2,9 @@ cmake_minimum_required(VERSION 3.7)
 project(glew LANGUAGES C)
 
 #---------------------------------File lists-----------------------------------
-set(source_files_relative
+set(source_files
     glew.c
 )
-set(source_files "")
-foreach(source_file_relative ${source_files_relative})
-    list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
-endforeach()
 
 #----------------------------------Compiling-----------------------------------
 add_library(glew STATIC ${source_files})

--- a/src/GL/CMakeLists.txt
+++ b/src/GL/CMakeLists.txt
@@ -1,36 +1,34 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(glew)
+cmake_minimum_required(VERSION 3.7)
+project(glew LANGUAGES C)
 
 #---------------------------------File lists-----------------------------------
 set(source_files_relative
-	glew.c
+    glew.c
 )
 set(source_files "")
 foreach(source_file_relative ${source_files_relative})
-	list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
+    list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
 endforeach()
-
-include_directories(
-	${CMAKE_CURRENT_BINARY_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/.. #Because the header files are requested starting from "GL/..."
-)
 
 #----------------------------------Compiling-----------------------------------
 add_library(glew STATIC ${source_files})
 
+target_include_directories(glew
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
+
 #--------------------------------Installation----------------------------------
 install(
-	TARGETS glew
-	EXPORT glew
-	DESTINATION lib
+    TARGETS glew
+    EXPORT glew
+    DESTINATION lib
 )
 install(
-	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	DESTINATION include
-	FILES_MATCHING PATTERN "*.h"
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.h"
 )
 install(
-	EXPORT glew
-	DESTINATION share/glew
+    EXPORT glew
+    DESTINATION share/glew
 )

--- a/src/libopus/CMakeLists.txt
+++ b/src/libopus/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.7)
+project(opus LANGUAGES C)
+
 add_library(opus STATIC
 #    celt/arm/arm_celt_map.c
 #    celt/arm/armcpu.c

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7)
 project(lua LANGUAGES C)
 
 #---------------------------------File lists-----------------------------------
-set(source_files_relative
+set(source_files
 	lapi.c
 	lauxlib.c
 	lbaselib.c
@@ -33,12 +33,6 @@ set(source_files_relative
 	lvm.c
 	lzio.c
 )
-set(source_files "")
-foreach(source_file_relative ${source_files_relative})
-	list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
-endforeach()
-
-
 
 #----------------------------------Compiling-----------------------------------
 add_library(lua STATIC ${source_files})

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(Box2D)
+cmake_minimum_required(VERSION 3.7)
+project(lua LANGUAGES C)
 
 #---------------------------------File lists-----------------------------------
 set(source_files_relative
@@ -38,14 +38,14 @@ foreach(source_file_relative ${source_files_relative})
 	list(APPEND source_files ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_relative})
 endforeach()
 
-include_directories(
-	${CMAKE_CURRENT_BINARY_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/.. #Because the header files are requested starting from "lua/..."
-)
+
 
 #----------------------------------Compiling-----------------------------------
 add_library(lua STATIC ${source_files})
+
+target_include_directories(lua
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
 #--------------------------------Installation----------------------------------
 install(


### PR DESCRIPTION
* Updated to C++14
* Moved dependencies to the engine: it now drives the download of SFML / Dr. MinGW, and provides their install targets.
* Moved optimization flags, defines to the seriousproton target.
* Removed source_files / source_files_relative shenanigans
* Allowed Dr. MinGW to be used across any windows compiler. This is conditional to #69 
* Added missing SeriousProton cpp files.

All this combined means one can now use seriousproton from a `add_subdirectory()` command, only providing a handful of defines (namely the version number and window title).

Even when the source is out-of-tree (ie: I'm using the same trick that's done for [libopus](https://github.com/daid/EmptyEpsilon/blob/4f19d51c3b2bf74d619812b89315f73046cae819/CMakeLists.txt#L442) in EE and it works like a charm).