### PR TITLE
Fixed joystick axis scaling

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -126,14 +126,19 @@ void InputHandler::handleEvent(sf::Event& event)
     }
     else if (event.type == sf::Event::JoystickMoved)
     {
-        float axis_pos;
+        static constexpr float scale_factor = 100.f / (100.f - joystick_axis_snap_to_0_range);
+
+        float axis_pos = 0.f;
+        
         if (event.joystickMove.position > joystick_axis_snap_to_0_range) {
-            axis_pos = (event.joystickMove.position - joystick_axis_snap_to_0_range) * ((joystick_axis_snap_to_0_range / 100) + 1);
+            axis_pos = (event.joystickMove.position - joystick_axis_snap_to_0_range) * scale_factor;
         } else if (event.joystickMove.position < -joystick_axis_snap_to_0_range) {
-            axis_pos = (event.joystickMove.position + joystick_axis_snap_to_0_range) * ((joystick_axis_snap_to_0_range / 100) + 1);
-        } else {
-            axis_pos = 0.0;
+            axis_pos = (event.joystickMove.position + joystick_axis_snap_to_0_range) * scale_factor;
         }
+
+        // Clamp axis_pos within SFML range.
+        axis_pos = std::min(std::max(-100.f, axis_pos), 100.f);
+
         if (joystick_axis_pos[event.joystickMove.joystickId][event.joystickMove.axis] != axis_pos){
             joystick_axis_changed[event.joystickMove.joystickId][event.joystickMove.axis] = true;
         }


### PR DESCRIPTION
The old code scaled by `1.05`, which is *not* the same as `100 / 95` (`= 1.0526315789473684210526315789474`)

That effectively capped the axis to 99.75 (95 * 1.05), instead of being able to reach 100.

fixes daid/EmptyEpsilon#1035