### PR TITLE
Disallow opening empty file sfml buffers

### DIFF
--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -57,8 +57,15 @@ class FileResourceStream : public ResourceStream
 public:
     FileResourceStream(string filename)
     {
-        if(!std::filesystem::is_regular_file(filename.c_str()))
+        std::error_code ec;
+        if(!std::filesystem::is_regular_file(filename.c_str()), ec)
+        {
+            if(ec)
+            {
+                LOG(ERROR) << "OS error on file check : " << ec.message();
+            }
             open_success = false;
+        }
         else
             open_success = stream.open(filename);
     }

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -8,6 +8,7 @@
 #include <dirent.h>
 #endif
 #include <cstdio>
+#include <filesystem>
 
 PVector<ResourceProvider> resourceProviders;
 
@@ -56,7 +57,10 @@ class FileResourceStream : public ResourceStream
 public:
     FileResourceStream(string filename)
     {
-        open_success = stream.open(filename);
+        if(!std::filesystem::is_regular_file(filename.c_str()))
+            open_success = false;
+        else
+            open_success = stream.open(filename);
     }
     virtual ~FileResourceStream()
     {


### PR DESCRIPTION
Corrects a freeze in case of empty sound file on linux