### PR TITLE
Pass by reference for textureManager API

### DIFF
--- a/src/textureManager.cpp
+++ b/src/textureManager.cpp
@@ -16,7 +16,7 @@ TextureManager::~TextureManager()
 {
 }
 
-void TextureManager::setTexture(sf::Sprite& sprite, string name, unsigned int spriteIndex)
+void TextureManager::setTexture(sf::Sprite& sprite, const string& name, unsigned int spriteIndex)
 {
     TextureData& data = textureMap[name];
     if (data.texture.getSize().x < 1)
@@ -33,7 +33,7 @@ void TextureManager::setTexture(sf::Sprite& sprite, string name, unsigned int sp
     }
 }
 
-sf::Texture* TextureManager::getTexture(string name, sf::Vector2i subDiv)
+sf::Texture* TextureManager::getTexture(const string& name, sf::Vector2i subDiv)
 {
     if (disabled)
         return nullptr;
@@ -43,7 +43,7 @@ sf::Texture* TextureManager::getTexture(string name, sf::Vector2i subDiv)
     return &data.texture;
 }
 
-const sf::IntRect TextureManager::getSpriteRect(string name, unsigned int spriteIndex)
+const sf::IntRect TextureManager::getSpriteRect(const string& name, unsigned int spriteIndex)
 {
     TextureData& data = textureMap[name];
     if (data.texture.getSize().x < 1)
@@ -55,7 +55,7 @@ const sf::IntRect TextureManager::getSpriteRect(string name, unsigned int sprite
     return sf::IntRect(sf::Vector2i(0, 0), sf::Vector2i(data.texture.getSize()));
 }
 
-void TextureManager::setSpriteRect(string name, unsigned int spriteIndex, const sf::IntRect rect)
+void TextureManager::setSpriteRect(const string& name, unsigned int spriteIndex, const sf::IntRect rect)
 {
     TextureData& data = textureMap[name];
     if (data.texture.getSize().x < 1)
@@ -67,7 +67,7 @@ void TextureManager::setSpriteRect(string name, unsigned int spriteIndex, const 
         data.sprites.push_back(rect);
 }
 
-void TextureManager::loadTexture(string name, sf::Vector2i subDiv)
+void TextureManager::loadTexture(const string& name, sf::Vector2i subDiv)
 {
     TextureData& data = textureMap[name];
     

--- a/src/textureManager.h
+++ b/src/textureManager.h
@@ -31,13 +31,13 @@ public:
     void setAutoSprite(bool enabled) { autoSprite = enabled; }
     void setDisabled(bool disable) { disabled = disable; }
     
-    void setTexture(sf::Sprite& sprite, string name, unsigned int spriteIndex = 0);
-    const sf::IntRect getSpriteRect(string name, unsigned int spriteIndex = 0);
-    void setSpriteRect(string name, unsigned int spriteIndex, const sf::IntRect rect);
+    void setTexture(sf::Sprite& sprite, const string& name, unsigned int spriteIndex = 0);
+    const sf::IntRect getSpriteRect(const string& name, unsigned int spriteIndex = 0);
+    void setSpriteRect(const string& name, unsigned int spriteIndex, const sf::IntRect rect);
 
-    sf::Texture* getTexture(string name, sf::Vector2i subDiv = sf::Vector2i(0, 0));
+    sf::Texture* getTexture(const string& name, sf::Vector2i subDiv = sf::Vector2i(0, 0));
 private:
-    void loadTexture(string name, sf::Vector2i subDiv);
+    void loadTexture(const string& name, sf::Vector2i subDiv);
 };
 
 #endif//TEXTURE_MANAGER_H


### PR DESCRIPTION
Avoids extra copies (which show up on my radar) each time someone calls `getTexture()` for instance.