### PR TITLE
Being able to list android files

### DIFF
--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -107,8 +107,8 @@ public:
 
 
 DirectoryResourceProvider::DirectoryResourceProvider(string basepath)
-: basepath(basepath)
 {
+  this->basepath = basepath.endswith("/") ? basepath.substr(0,basepath.size()-1) : basepath;
 }
 
 P<ResourceStream> DirectoryResourceProvider::getResourceStream(string filename)
@@ -147,7 +147,6 @@ std::vector<string> DirectoryResourceProvider::findResources(string searchPatter
         AAssetDir* dir = AAssetManager_openDir(asset_manager, (forced_path).c_str());
         if (dir)
         {
-            AAssetDir_rewind(dir);
             const char* filename;
             while ((filename = AAssetDir_getNextFileName(dir)) != nullptr)
             {

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -108,7 +108,7 @@ public:
 
 DirectoryResourceProvider::DirectoryResourceProvider(string basepath)
 {
-  this->basepath = basepath.endswith("/") ? basepath.substr(0,basepath.size()-1) : basepath;
+    this->basepath = basepath.rstrip("\\/");
 }
 
 P<ResourceStream> DirectoryResourceProvider::getResourceStream(string filename)

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -67,10 +67,8 @@ public:
         std::error_code ec;
         if(!std::filesystem::is_regular_file(filename.c_str(), ec))
         {
-            if(ec)
-            {
-                LOG(ERROR) << "OS error on file check : " << ec.message();
-            }
+            //Error code "no such file or directory" thrown really often, so no trace here
+            //not to spam the log
             open_success = false;
         }
         else


### PR DESCRIPTION
This is to merge at the same time as the Empty Epsilon pull request daid/EmptyEpsilon#1412.
Allows to list Android assets. 
This allow for instance to see the scenario list in Android.
Also, changes behavior on slashes on directory providers (see Empty Epsilon PR)
Also suppress the "no such file or directory" spam in log files.