### PR TITLE
Expose a disconnect 'reason'

### DIFF
--- a/src/multiplayer_client.cpp
+++ b/src/multiplayer_client.cpp
@@ -222,7 +222,8 @@ void GameClient::update(float /*delta*/)
     auto timed_out = last_receive_time.getElapsedTime().asSeconds() > no_data_disconnect_time;
     if (socket_status == sf::TcpSocket::Disconnected || timed_out)
     {
-        disconnect_reason = timed_out ? DisconnectReason::TimedOut : DisconnectReason::ClosedByServer;
+        if (disconnect_reason == DisconnectReason::None)
+            disconnect_reason = timed_out ? DisconnectReason::TimedOut : DisconnectReason::ClosedByServer;
         socket.disconnect();
         status = Disconnected;
     }

--- a/src/multiplayer_client.cpp
+++ b/src/multiplayer_client.cpp
@@ -77,6 +77,8 @@ void GameClient::update(float /*delta*/)
 
                     if (server_version != 0 && server_version != version_number)
                     {
+                        require_password = false; // forcibly send an empty pass, we're about to fail anyway.
+                        disconnect_reason = DisconnectReason::VersionMismatch;
                         LOG(INFO) << "Server version " << server_version << " does not match client version " << version_number;
                     }
 
@@ -93,6 +95,7 @@ void GameClient::update(float /*delta*/)
             case CMD_SET_CLIENT_ID:
                 packet >> client_id;
                 status = Connected;
+                disconnect_reason = DisconnectReason::None;
                 break;
             case CMD_ALIVE:
                 // send response to calculate ping
@@ -216,8 +219,10 @@ void GameClient::update(float /*delta*/)
         }
     }
 
-    if (socket_status == sf::TcpSocket::Disconnected || last_receive_time.getElapsedTime().asSeconds() > no_data_disconnect_time)
+    auto timed_out = last_receive_time.getElapsedTime().asSeconds() > no_data_disconnect_time;
+    if (socket_status == sf::TcpSocket::Disconnected || timed_out)
     {
+        disconnect_reason = timed_out ? DisconnectReason::TimedOut : DisconnectReason::ClosedByServer;
         socket.disconnect();
         status = Disconnected;
     }
@@ -233,6 +238,7 @@ void GameClient::sendPassword(string password)
     if (status != WaitingForPassword)
         return;
 
+    disconnect_reason = DisconnectReason::BadCredentials;
     sf::Packet reply;
     reply << CMD_CLIENT_SEND_AUTH << int32_t(version_number) << password;
     socket.send(reply);

--- a/src/multiplayer_client.h
+++ b/src/multiplayer_client.h
@@ -25,6 +25,16 @@ public:
         Connected,
         Disconnected
     };
+
+    enum class DisconnectReason : uint8_t
+    {
+        None = 0,
+        VersionMismatch,
+        BadCredentials,
+        TimedOut,
+        ClosedByServer, // Normal termination.
+        Unknown
+    };
 private:
     int version_number;
     sf::IpAddress server;
@@ -38,6 +48,7 @@ private:
     NetworkAudioStreamManager audio_stream_manager;
 
     sf::Thread connect_thread;
+    DisconnectReason disconnect_reason{ DisconnectReason::Unknown };
 public:
     GameClient(int version_number, sf::IpAddress server, int port_nr = defaultServerPort);
     virtual ~GameClient();
@@ -47,6 +58,7 @@ public:
 
     int32_t getClientId() { return client_id; }
     Status getStatus() { return status; }
+    DisconnectReason getDisconnectReason() const { return disconnect_reason; }
 
     void sendPacket(sf::Packet& packet);
 


### PR DESCRIPTION
This is to cover, in part, daid/EmptyEpsilon#940 : the client will remember the last potential reason for a failed connection.

It's the necessary ground work to then be able to muster up some sort of error message in the player's UI.