### PR TITLE
Initial draft for reducing CPU usage on the server

### DIFF
--- a/src/multiplayer.cpp
+++ b/src/multiplayer.cpp
@@ -4,6 +4,16 @@
 #include "engine.h"
 #include "multiplayer_internal.h"
 
+
+void MultiplayerStaticReplicationBase::markChanged()
+{
+    if (updated) return;
+    updated = true;
+    next = owner->staticMemberSendList;
+    owner->staticMemberSendList = this;
+}
+
+
 static PVector<Collisionable> collisionable_significant;
 class CollisionableReplicationData
 {

--- a/src/multiplayer_client.cpp
+++ b/src/multiplayer_client.cpp
@@ -129,7 +129,9 @@ void GameClient::update(float /*delta*/)
                                 int16_t idx;
                                 while(packet >> idx)
                                 {
-                                    if (idx >= 0 && idx < int16_t(obj->memberReplicationInfo.size()))
+                                    if (idx & 0x8000 && (idx & 0x7FFF) < uint16_t(obj->staticMemberReplicationInfo.size()))
+                                        obj->staticMemberReplicationInfo[idx & 0x7FFF]->receive(packet);
+                                    else if (idx >= 0 && idx < int16_t(obj->memberReplicationInfo.size()))
                                         (obj->memberReplicationInfo[idx].receiveFunction)(obj->memberReplicationInfo[idx].ptr, packet);
                                     else
                                         LOG(DEBUG) << "Odd index from server replication: " << idx;
@@ -157,7 +159,9 @@ void GameClient::update(float /*delta*/)
                         P<MultiplayerObject> obj = objectMap[id];
                         while(packet >> idx)
                         {
-                            if (idx < int32_t(obj->memberReplicationInfo.size()))
+                            if (idx & 0x8000 && (idx & 0x7FFF) < uint16_t(obj->staticMemberReplicationInfo.size()))
+                                obj->staticMemberReplicationInfo[idx & 0x7FFF]->receive(packet);
+                            else if (idx < int32_t(obj->memberReplicationInfo.size()))
                                 (obj->memberReplicationInfo[idx].receiveFunction)(obj->memberReplicationInfo[idx].ptr, packet);
                         }
                     }

--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -164,6 +164,15 @@ void GameServer::update(float /*gameDelta*/)
                     }
                 }
             }
+            while(obj->staticMemberSendList)
+            {
+                packet << obj->staticMemberSendList->replication_id;
+                obj->staticMemberSendList->send(packet);
+                //TODO: Multiplayer stats
+                obj->staticMemberSendList->updated = false;
+                obj->staticMemberSendList = obj->staticMemberSendList->next;
+                cnt ++;
+            }
             if (cnt > 0)
             {
                 sendAll(packet);
@@ -528,6 +537,11 @@ void GameServer::generateCreatePacketFor(P<MultiplayerObject> obj, sf::Packet& p
     {
         packet << int16_t(n);
         (obj->memberReplicationInfo[n].sendFunction)(obj->memberReplicationInfo[n].ptr, packet);
+    }
+    for(unsigned int n=0; n<obj->staticMemberReplicationInfo.size(); n++)
+    {
+        packet << int16_t(n | 0x8000);
+        obj->staticMemberReplicationInfo[n]->send(packet);
     }
 }
 


### PR DESCRIPTION
This works by having configuration values use a different method to check for changes.

Example usage, just replace a member this way:
Old:
```C++
int32_t parent_id = 0;
```
New:
```C++
MultiplayerStaticReplication<int32_t> parent_id = 0;
```

This makes the parent_id into a facade towards an int32_t, and any writes to it will mark it as update required.

Note, I only checked if this compiled, didn't check if it functions correctly.
The MultiplayerStaticReplication template most likely will need a few more operators and stuff for a better facade.