### PR TITLE
Improved replication

### DIFF
--- a/src/multiplayer.cpp
+++ b/src/multiplayer.cpp
@@ -4,6 +4,16 @@
 #include "engine.h"
 #include "multiplayer_internal.h"
 
+
+void MultiplayerStaticReplicationBase::markChanged()
+{
+    if (updated) return;
+    updated = true;
+    next = owner->staticMemberSendList;
+    owner->staticMemberSendList = this;
+}
+
+
 static PVector<Collisionable> collisionable_significant;
 class CollisionableReplicationData
 {

--- a/src/multiplayer_client.cpp
+++ b/src/multiplayer_client.cpp
@@ -126,12 +126,12 @@ void GameClient::update(float /*delta*/)
                                 obj->multiplayerObjectId = id;
                                 objectMap[id] = obj;
 
-                                int16_t idx;
+                                int16_t idx{};
                                 while(packet >> idx)
                                 {
-                                    if (idx & 0x8000 && (idx & 0x7FFF) < uint16_t(obj->staticMemberReplicationInfo.size()))
-                                        obj->staticMemberReplicationInfo[idx & 0x7FFF]->receive(packet);
-                                    else if (idx >= 0 && idx < int16_t(obj->memberReplicationInfo.size()))
+                                    if (obj->replicationControl->handles(idx))
+                                        obj->replicationControl->receive(idx, packet);
+                                    else if (idx >= 0 && idx < uint16_t(obj->memberReplicationInfo.size()))
                                         (obj->memberReplicationInfo[idx].receiveFunction)(obj->memberReplicationInfo[idx].ptr, packet);
                                     else
                                         LOG(DEBUG) << "Odd index from server replication: " << idx;
@@ -159,8 +159,8 @@ void GameClient::update(float /*delta*/)
                         P<MultiplayerObject> obj = objectMap[id];
                         while(packet >> idx)
                         {
-                            if (idx & 0x8000 && (idx & 0x7FFF) < uint16_t(obj->staticMemberReplicationInfo.size()))
-                                obj->staticMemberReplicationInfo[idx & 0x7FFF]->receive(packet);
+                            if (obj->replicationControl->handles(idx))
+                                obj->replicationControl->receive(idx, packet);
                             else if (idx < int32_t(obj->memberReplicationInfo.size()))
                                 (obj->memberReplicationInfo[idx].receiveFunction)(obj->memberReplicationInfo[idx].ptr, packet);
                         }

--- a/src/multiplayer_client.cpp
+++ b/src/multiplayer_client.cpp
@@ -129,7 +129,9 @@ void GameClient::update(float /*delta*/)
                                 int16_t idx;
                                 while(packet >> idx)
                                 {
-                                    if (idx >= 0 && idx < int16_t(obj->memberReplicationInfo.size()))
+                                    if (idx & 0x8000 && (idx & 0x7FFF) < uint16_t(obj->staticMemberReplicationInfo.size()))
+                                        obj->staticMemberReplicationInfo[idx & 0x7FFF]->receive(packet);
+                                    else if (idx >= 0 && idx < int16_t(obj->memberReplicationInfo.size()))
                                         (obj->memberReplicationInfo[idx].receiveFunction)(obj->memberReplicationInfo[idx].ptr, packet);
                                     else
                                         LOG(DEBUG) << "Odd index from server replication: " << idx;
@@ -157,7 +159,9 @@ void GameClient::update(float /*delta*/)
                         P<MultiplayerObject> obj = objectMap[id];
                         while(packet >> idx)
                         {
-                            if (idx < int32_t(obj->memberReplicationInfo.size()))
+                            if (idx & 0x8000 && (idx & 0x7FFF) < uint16_t(obj->staticMemberReplicationInfo.size()))
+                                obj->staticMemberReplicationInfo[idx & 0x7FFF]->receive(packet);
+                            else if (idx < int32_t(obj->memberReplicationInfo.size()))
                                 (obj->memberReplicationInfo[idx].receiveFunction)(obj->memberReplicationInfo[idx].ptr, packet);
                         }
                     }

--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -165,7 +165,7 @@ void GameServer::update(float /*gameDelta*/)
                 }
             }
 
-            cnt += obj->replicationControl->send(packet, false);
+            cnt += obj->replicationControl->send(packet, false, delta);
             if (cnt > 0)
             {
                 sendAll(packet);

--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -164,6 +164,15 @@ void GameServer::update(float /*gameDelta*/)
                     }
                 }
             }
+            while(obj->staticMemberSendList)
+            {
+                packet << obj->staticMemberSendList->replication_id;
+                obj->staticMemberSendList->send(packet);
+                //TODO: Multiplayer stats
+                obj->staticMemberSendList->updated = false;
+                obj->staticMemberSendList = obj->staticMemberSendList->next;
+                cnt ++;
+            }
             if (cnt > 0)
             {
                 sendAll(packet);
@@ -528,6 +537,11 @@ void GameServer::generateCreatePacketFor(P<MultiplayerObject> obj, sf::Packet& p
     {
         packet << int16_t(n);
         (obj->memberReplicationInfo[n].sendFunction)(obj->memberReplicationInfo[n].ptr, packet);
+    }
+    for(unsigned int n=0; n<obj->staticMemberReplicationInfo.size(); n++)
+    {
+        packet << int16_t(n | 0x8000);
+        obj->staticMemberReplicationInfo[n]->send(packet);
     }
 }
 

--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -164,15 +164,8 @@ void GameServer::update(float /*gameDelta*/)
                     }
                 }
             }
-            while(obj->staticMemberSendList)
-            {
-                packet << obj->staticMemberSendList->replication_id;
-                obj->staticMemberSendList->send(packet);
-                //TODO: Multiplayer stats
-                obj->staticMemberSendList->updated = false;
-                obj->staticMemberSendList = obj->staticMemberSendList->next;
-                cnt ++;
-            }
+
+            cnt += obj->replicationControl->send(packet, false);
             if (cnt > 0)
             {
                 sendAll(packet);
@@ -538,11 +531,8 @@ void GameServer::generateCreatePacketFor(P<MultiplayerObject> obj, sf::Packet& p
         packet << int16_t(n);
         (obj->memberReplicationInfo[n].sendFunction)(obj->memberReplicationInfo[n].ptr, packet);
     }
-    for(unsigned int n=0; n<obj->staticMemberReplicationInfo.size(); n++)
-    {
-        packet << int16_t(n | 0x8000);
-        obj->staticMemberReplicationInfo[n]->send(packet);
-    }
+
+    obj->replicationControl->send(packet, true);
 }
 
 void GameServer::generateDeletePacketFor(int32_t id, sf::Packet& packet)


### PR DESCRIPTION
This build's on @daid 's proposal from #115 .

It introduces a new type, `replication::Field<T>` which people can use to mark replicated... fields.

⚠️ This is still very much a draft, with an API in flux. Currently trying to match all existing functionalities (including debug features, network stats).

```cpp
class Sample : public MultiplayerObject
{
  float old_way;
  float old_way_interval;
  replication::Field<float> new_way;
  replication::Field<float> new_way_interval;
public:
  Sample()
  : new_way{this}, new_way_interval{this, 1.5f} // <- this part is likely to change slightly, but that's the concept
  {
    registerMemberReplication(&old_way);
    registerMemberReplication(&old_way_interval, 1.5f);
  }
};```

replicated fields can be used transparently in most context: a const-ref accessor is provided, and overloads are set for the most common writing operations (assignments mainly).

The replication handling has been moved into a dedicated class, the `ControlBlock` (modeling after the shared_ptr logic).

While it follow just about the same overall pattern as the current replication logic, the few improvements are:
  * It's type-safe. No more `void*` party.
  * It doesn't need to keep previous values around: items are marked dirty when they change (or are assigned for some objects where it is too expensive to do change detection).
  * It's faster at sorting out changed vs unchanged values: both from not having to check for change *each* attempt at updating and through using a bitset.
  * It's smaller: The current `MemberReplicationInfo` is about 48B on a 64b system, whereas the `Field<[trivial type]>` is only 32B. This currently includes padding, and could probably be shrunk a little more.

The API is aiming to be easy to use, hard to misuse while still being somewhat open ended to allow introducing custom Field types.

Again still WIP, still a draft, but would definitely appreciate any early insights or feedback.

Currently planned:
 * Field should take a setting-like struct at the beginning, currently it's a little confusing. So from `field{this, min_interval, field_args...}` to `field{ {this, min_interval, other_settings? }, field_args... }`
 * Multiplayer stats - still need a macro for the name injection etc. Will likely go from `: field{...}` to `: replicatedField(field, ...)`.
 * Vector support.