### PR TITLE
Bump SFML requirement to 2.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(ENABLE_CRASH_LOGGER)
 endif()
 
 #--------------------------------Dependencies----------------------------------
-find_package(SFML 2.4 COMPONENTS system audio network window graphics)
+find_package(SFML 2.5 COMPONENTS system audio network window graphics)
 if(NOT ${SFML_FOUND})
     message(STATUS "Couldn't find SFML. Building it from scratch.")
     


### PR DESCRIPTION
This comes after seeing issues with 2.4 - see daid/EmptyEpsilon#1445

Debian stable (buster) is unaffected since it already has sfml 2.5 as a system package.
Ubuntu 18.04 users would end up compiling locally.