### PR TITLE
Enhance the CMake code for MinGW Crash Logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,38 +9,42 @@ set(CMAKE_MODULE_PATH
 # User-settings
 option(SERIOUSPROTON_WITH_JSON "Use json library." OFF)
 
-if(WIN32)
-    option(ENABLE_CRASH_LOGGER "Enable the Dr. MinGW crash logging facilities" OFF)
-    set(DRMINGW_ROOT DRMINGW_ROOT-NOTFOUND CACHE PATH "Path to Dr. MinGW")
-endif()
-
-# Preflight checks.
-message(STATUS "Crash Logger is " ${ENABLE_CRASH_LOGGER})
-
+#
 set(EXTERNALS_DIR "${PROJECT_BINARY_DIR}/externals")
 set(DOWNLOADS_DIR "${PROJECT_BINARY_DIR}/downloads")
 file(MAKE_DIRECTORY "${EXTERNAL_DIR}" "${DOWNLOADS_DIR}")
 
-if(ENABLE_CRASH_LOGGER)
-    if(NOT DRMINGW_ROOT)
-        message("Downloading Dr. MinGW")
+# Crash Logger for MinGW
+if(WIN32)
+    option(ENABLE_CRASH_LOGGER "Enable the Dr. MinGW crash logging facilities" OFF)
+    set(DRMINGW_ROOT DRMINGW_ROOT-NOTFOUND CACHE PATH "Path to Dr. MinGW")
 
-        set(DRMINGW_ARCH "64")
-        if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
-            set(DRMINGW_ARCH "32")
-        endif()
+    if(NOT ENABLE_CRASH_LOGGER)
+        message(STATUS "Crash Logger is OFF")
+    else()
+        message(STATUS "Crash Logger is ON")
 
-        # 0.9.x seems to give a hard time to people on Win7.
-        # Sticking with 0.8 for that reason.
-        set(DRMINGW_VERSION "0.8.2")
-        set(DRMINGW_BASENAME "drmingw-${DRMINGW_VERSION}-win${DRMINGW_ARCH}")
-        set(DRMINGW_ROOT "${CMAKE_CURRENT_BINARY_DIR}/${DRMINGW_BASENAME}" CACHE PATH "Path to Dr. MinGW" FORCE)
+        if(NOT DRMINGW_ROOT)
+            message(VERBOSE "Downloading Dr. MinGW")
 
-        if(NOT EXISTS "${DRMINGW_ROOT}/bin/exchndl.dll")
-            set(DRMINGW_ZIP "${CMAKE_CURRENT_BINARY_DIR}/${DRMINGW_BASENAME}.7z")
-            
-            file(DOWNLOAD "https://github.com/jrfonseca/drmingw/releases/download/${DRMINGW_VERSION}/${DRMINGW_BASENAME}.7z" "${DRMINGW_ZIP}" TIMEOUT 60 TLS_VERIFY ON)
-            execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf "${DRMINGW_ZIP}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+            if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
+                set(DRMINGW_ARCH "32")
+            else()
+                set(DRMINGW_ARCH "64")
+            endif()
+
+            # 0.9.x seems to give a hard time to people on Win7.
+            # Sticking with 0.8 for that reason.
+            set(DRMINGW_VERSION "0.8.2")
+            set(DRMINGW_BASENAME "drmingw-${DRMINGW_VERSION}-win${DRMINGW_ARCH}")
+            set(DRMINGW_ROOT "${CMAKE_CURRENT_BINARY_DIR}/${DRMINGW_BASENAME}" CACHE PATH "Path to Dr. MinGW" FORCE)
+
+            if(NOT EXISTS "${DRMINGW_ROOT}/bin/exchndl.dll")
+                set(DRMINGW_ZIP "${CMAKE_CURRENT_BINARY_DIR}/${DRMINGW_BASENAME}.7z")
+
+                file(DOWNLOAD "https://github.com/jrfonseca/drmingw/releases/download/${DRMINGW_VERSION}/${DRMINGW_BASENAME}.7z" "${DRMINGW_ZIP}" TIMEOUT 60 TLS_VERIFY ON)
+                execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf "${DRMINGW_ZIP}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+            endif()
         endif()
     endif()
 endif()


### PR DESCRIPTION
 - Wrap the whole code as Windows-only
 - Hide the status message on non-Windows builds
 - Fix the status message output (the perivously used BOOL did not expaned to "ON"/"OFF" strings)
 - Mark download message mode to VERBOSE
 - Enhance readibility of the DRMINGW_ARCH; the set() is called only once in all cases