### PR TITLE
Remove designated initializers

### DIFF
--- a/src/graphics/font.cpp
+++ b/src/graphics/font.cpp
@@ -43,9 +43,9 @@ Font::PreparedFontString Font::prepare(std::string_view s, int pixel_size, float
             position.x += getKerning(previous_char_code, char_info.code) * size_scale;
         }
         result.data.push_back({
-            .position = position,
-            .char_code = char_info.code,
-            .string_offset = int(index),
+            /*.position =*/ position,
+            /*.char_code =*/ char_info.code,
+            /*.string_offset =*/ int(index),
         });
         previous_char_code = char_info.code;
         index += char_info.consumed_bytes;
@@ -98,9 +98,9 @@ Font::PreparedFontString Font::prepare(std::string_view s, int pixel_size, float
         }
     }
     result.data.push_back({
-        .position = position,
-        .char_code = 0,
-        .string_offset = int(s.size()),
+        /*.position =*/ position,
+        /*.char_code =*/ 0,
+        /*.string_offset =*/ int(s.size()),
     });
 
     result.alignAll();

--- a/src/graphics/image.cpp
+++ b/src/graphics/image.cpp
@@ -84,9 +84,9 @@ static int stream_eof(void *user)
 }
 
 static stbi_io_callbacks stream_callbacks{
-    .read = stream_read,
-    .skip = stream_skip,
-    .eof = stream_eof,
+    /*.read =*/ stream_read,
+    /*.skip =*/ stream_skip,
+    /*.eof =*/ stream_eof,
 };
 
 bool Image::loadFromStream(P<ResourceStream> stream)


### PR DESCRIPTION
Sadly they're C++20, and our current standard target (from CMakeLists) is C++17.