### PR TITLE
Wrap non-standard #warning

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -7,7 +7,12 @@ glm::mat3x3 InputHandler::mouse_transform;
 PVector<InputEventHandler> InputHandler::input_event_handlers;
 PVector<JoystickEventHandler> InputHandler::joystick_event_handlers;
 
-#warning TODO SDL2 this no longer works, SDLK_Keycode will be out of range. Port SP2 keybindings.
+#ifndef _MSVC_VER
+#warning TODO SDL2 this no longer works, SDLK_Keycode will be out of range.Port SP2 keybindings.
+#else
+#pragma message("TODO SDL2 this no longer works, SDLK_Keycode will be out of range.Port SP2 keybindings.")
+#endif
+
 bool InputHandler::keyboard_button_down[256];
 bool InputHandler::keyboard_button_pressed[256];
 bool InputHandler::keyboard_button_released[256];
@@ -194,7 +199,12 @@ void InputHandler::postEventsUpdate()
     SDL_GetMouseState(&x, &y);
     mouse_position = realWindowPosToVirtual({x, y});
 #endif
+#ifndef _MSC_VER
 #warning SDL2 TODO
+#else
+#pragma message("SDL2 TODO")
+#endif
+
     //mouse_position = mouse_transform * mouse_position;
     
     if (touch_screen)

--- a/src/networkRecorder.cpp
+++ b/src/networkRecorder.cpp
@@ -12,7 +12,11 @@
 
 NetworkAudioRecorder::NetworkAudioRecorder()
 {
+#ifndef _MSC_VER
 #warning SDL2 TODO
+#else
+#pragma message("SDL2 TODO")
+#endif
     //LOG(INFO) << "Using \"" << getDefaultDevice() << "\" for voice communication";
     //setProcessingInterval(sf::milliseconds(10));
 }

--- a/src/postProcessManager.cpp
+++ b/src/postProcessManager.cpp
@@ -7,7 +7,11 @@ bool PostProcessor::global_post_processor_enabled = true;
 PostProcessor::PostProcessor(string name, RenderChain* chain)
 : chain(chain), enabled{false}
 {
-#warning SDL2 TODO post processors not implemented, might remove them?
+#ifndef _MSVC_VER
+#warning SDL2 TODO post processors not implemented, might remove them ?
+#else
+#pragma message("SDL2 TODO post processors not implemented, might remove them?")
+#endif
     /*
     if (sf::Shader::isAvailable())
     {

--- a/src/windowManager.cpp
+++ b/src/windowManager.cpp
@@ -45,7 +45,11 @@ WindowManager::~WindowManager()
 
 void WindowManager::render()
 {
+#ifndef _MSC_VER
 #warning SDL2 TODO
+#else
+#pragma message("SDL2 TODO")
+#endif
 /*
     if (InputHandler::keyboardIsPressed(sf::Keyboard::Return) && (sf::Keyboard::isKeyPressed(sf::Keyboard::LAlt) || sf::Keyboard::isKeyPressed(sf::Keyboard::RAlt)))
     {
@@ -71,7 +75,11 @@ void WindowManager::render()
 
 void WindowManager::close()
 {
+#ifndef _MSC_VER
 #warning SDL2 TODO
+#else
+#pragma message("SDL2 TODO")
+#endif
 }
 
 void WindowManager::setFullscreen(bool new_fullscreen)
@@ -110,7 +118,11 @@ glm::vec2 WindowManager::mapPixelToCoords(const glm::ivec2 point) const
 
 glm::ivec2 WindowManager::mapCoordsToPixel(const glm::vec2 point) const
 {
+#ifndef _MSC_VER
 #warning SDL2 TODO
+#else
+#pragma message("SDL2 TODO")
+#endif
     return glm::ivec2(0, 0);
 }
 


### PR DESCRIPTION
Wrap non standard #warning for msvc.

Seeing these are transient and seldom, I went for the shortest fix by shielding the handful of instances.