### PR TITLE
Remove gxvfgen.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ add_library(spfreetype2 STATIC
         #libs/freetype2/src/gxvalid/gxvopbd.c
         #libs/freetype2/src/gxvalid/gxvprop.c
         #libs/freetype2/src/gxvalid/gxvtrak.c
-    libs/freetype2/src/gxvalid/gxvfgen.c
+    #libs/freetype2/src/gxvalid/gxvfgen.c
     libs/freetype2/src/gzip/ftgzip.c
         #libs/freetype2/src/gzip/adler32.c
         #libs/freetype2/src/gzip/infblock.c


### PR DESCRIPTION
Looking at its source, it says it's a standalone executable and is never compiled in the lib: https://github.com/daid/SeriousProton/blob/SDL2/libs/freetype2/src/gxvalid/gxvfgen.c#L49