### PR TITLE
Fix mouse button mappings

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -26,7 +26,7 @@ bool InputHandler::joystick_button_changed[4][4];
 
 namespace
 {
-    constexpr size_t sdl_mouse_button_cast(Uint8 sdl_button)
+    size_t sdl_mouse_button_cast(Uint8 sdl_button)
     {
         auto button = InputHandler::MouseButton::Left;
         switch (sdl_button)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -24,6 +24,37 @@ float InputHandler::joystick_axis_changed[4][4];
 bool InputHandler::joystick_button_down[4][4];
 bool InputHandler::joystick_button_changed[4][4];
 
+namespace
+{
+    constexpr size_t sdl_mouse_button_cast(Uint8 sdl_button)
+    {
+        auto button = InputHandler::MouseButton::Left;
+        switch (sdl_button)
+        {
+        case SDL_BUTTON_LEFT:
+            break;
+        case SDL_BUTTON_RIGHT:
+            button = InputHandler::MouseButton::Right;
+            break;
+        case SDL_BUTTON_MIDDLE:
+            button = InputHandler::MouseButton::Middle;
+            break;
+        case SDL_BUTTON_X1:
+            button = InputHandler::MouseButton::X1;
+            break;
+        case SDL_BUTTON_X2:
+            button = InputHandler::MouseButton::X2;
+            break;
+        default:
+            SDL_assert(false); // Shouldn't reach there!
+            // Map any remaining button to the left one.
+        }
+
+        
+        return static_cast<std::underlying_type_t<InputHandler::MouseButton>>(button);
+    }
+}
+
 InputEventHandler::InputEventHandler()
 {
     InputHandler::input_event_handlers.push_back(this);
@@ -117,13 +148,13 @@ void InputHandler::handleEvent(const SDL_Event& event)
         mouse_wheel_delta += event.wheel.y;
     if (event.type == SDL_MOUSEBUTTONDOWN)
     {
-        mouse_button_down[event.button.button] = true;
-        mouse_button_pressed[event.button.button] = true;
+        mouse_button_down[sdl_mouse_button_cast(event.button.button)] = true;
+        mouse_button_pressed[sdl_mouse_button_cast(event.button.button)] = true;
     }
     else if (event.type == SDL_MOUSEBUTTONUP)
     {
-        mouse_button_down[event.button.button] = false;
-        mouse_button_released[event.button.button] = true;
+        mouse_button_down[sdl_mouse_button_cast(event.button.button)] = false;
+        mouse_button_released[sdl_mouse_button_cast(event.button.button)] = true;
     }
     /*
     else if (event.type == SDL_JOYAXISMOTION)

--- a/src/input.h
+++ b/src/input.h
@@ -5,6 +5,8 @@
 #include "Updatable.h"
 #include <SDL.h>
 
+#include <type_traits>
+
 
 class InputEventHandler: public virtual PObject
 {
@@ -32,6 +34,15 @@ private:
 class InputHandler
 {
 public:
+    enum class MouseButton : uint8_t
+    {
+        Left = 0,
+        Right,
+        Middle,
+        X1,
+        X2
+    };
+
     static bool touch_screen;
     static glm::mat3x3 mouse_transform;
 
@@ -44,9 +55,13 @@ public:
 
     static glm::vec2 getMousePos() { return mouse_position; }
     static void setMousePos(glm::vec2 position);
-    static bool mouseIsDown(int button) { return mouse_button_down[button]; }
-    static bool mouseIsPressed(int button) { return mouse_button_pressed[button]; }
-    static bool mouseIsReleased(int button) { return !mouse_button_pressed[button] && mouse_button_released[button]; }
+    static bool mouseIsDown(MouseButton button) { return mouse_button_down[static_cast<std::underlying_type_t<MouseButton>>(button)]; }
+    static bool mouseIsPressed(MouseButton button) { return mouse_button_pressed[static_cast<std::underlying_type_t<MouseButton>>(button)]; }
+    static bool mouseIsReleased(MouseButton button) { return !mouse_button_pressed[static_cast<std::underlying_type_t<MouseButton>>(button)] && mouse_button_released[static_cast<std::underlying_type_t<MouseButton>>(button)]; }
+
+    static [[deprecated("Use mouseIsDown(MouseButton)")]] bool mouseIsDown(uint8_t button) { return mouseIsDown(MouseButton{ button }); }
+    static [[deprecated("Use mouseIsPressed(MouseButton)")]] bool mouseIsPressed(uint8_t button) { return mouseIsPressed(MouseButton{ button }); }
+    static [[deprecated("Use mouseIsReleased(MouseButton)")]] bool mouseIsReleased(uint8_t button) { return mouseIsReleased(MouseButton{ button }); }
     static float getMouseWheelDelta() { return mouse_wheel_delta; }
     
     static glm::vec2    getJoysticXYPos() { return glm::vec2(joystick_axis_pos[0][0], joystick_axis_pos[0][1]); }

--- a/src/input.h
+++ b/src/input.h
@@ -59,9 +59,9 @@ public:
     static bool mouseIsPressed(MouseButton button) { return mouse_button_pressed[static_cast<std::underlying_type_t<MouseButton>>(button)]; }
     static bool mouseIsReleased(MouseButton button) { return !mouse_button_pressed[static_cast<std::underlying_type_t<MouseButton>>(button)] && mouse_button_released[static_cast<std::underlying_type_t<MouseButton>>(button)]; }
 
-    static [[deprecated("Use mouseIsDown(MouseButton)")]] bool mouseIsDown(uint8_t button) { return mouseIsDown(MouseButton{ button }); }
-    static [[deprecated("Use mouseIsPressed(MouseButton)")]] bool mouseIsPressed(uint8_t button) { return mouseIsPressed(MouseButton{ button }); }
-    static [[deprecated("Use mouseIsReleased(MouseButton)")]] bool mouseIsReleased(uint8_t button) { return mouseIsReleased(MouseButton{ button }); }
+    [[deprecated("Use mouseIsDown(MouseButton)")]] static bool mouseIsDown(uint8_t button) { return mouseIsDown(MouseButton{ button }); }
+    [[deprecated("Use mouseIsPressed(MouseButton)")]] static bool mouseIsPressed(uint8_t button) { return mouseIsPressed(MouseButton{ button }); }
+    [[deprecated("Use mouseIsReleased(MouseButton)")]] static bool mouseIsReleased(uint8_t button) { return mouseIsReleased(MouseButton{ button }); }
     static float getMouseWheelDelta() { return mouse_wheel_delta; }
     
     static glm::vec2    getJoysticXYPos() { return glm::vec2(joystick_axis_pos[0][0], joystick_axis_pos[0][1]); }


### PR DESCRIPTION
Remap SDL mouse buttons to what the rest of the world (ie EE) expects.

Provide a backward-compatible enum so code can start using named values instead of hardcoded constants.