### PR TITLE
Enable warning as error by default

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,7 +76,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $env:GITHUB_WORKSPACE -G "Visual Studio 16 2019" -A Win32 -DCMAKE_BUILD_TYPE:STRING=${{ matrix.build_type }} -DSDL2_DIR:PATH="$env:GITHUB_WORKSPACE/externals"
+      run: cmake $env:GITHUB_WORKSPACE -G "Visual Studio 16 2019" -A Win32 -DCMAKE_BUILD_TYPE:STRING=${{ matrix.build_type }} -DSDL2_DIR:PATH="$env:GITHUB_WORKSPACE/externals" -DWARNING_IS_ERROR=1
     - name: Configure CMake (unix-like)
       if: ${{ !startsWith(matrix.os, 'windows') }}
       # Use a bash shell so we can use the same syntax for environment variable
@@ -86,7 +86,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+      run: cmake $GITHUB_WORKSPACE -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DWARNING_IS_ERROR=1
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # User-settings
 option(SERIOUSPROTON_WITH_JSON "Use json library." OFF)
-set(WARNING_IS_ERROR ON)
+set(WARNING_IS_ERROR OFF)
 
 #
 set(EXTERNALS_DIR "${PROJECT_BINARY_DIR}/externals")


### PR DESCRIPTION
And set them as private options on the objects - this way SP itself *always* compiles its sources with warning as errors, even when build consumer projects (ie EE).

Consumer projects remain unaffected and can have a different warning level.