### PR TITLE
Fix glDebug.inl command dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ set(glDebug_inl "${CMAKE_CURRENT_BINARY_DIR}/include/graphics/glDebug.inl")
 add_custom_command(
     OUTPUT "${glDebug_inl}"
     COMMAND ${CMAKE_COMMAND} -Dglad_h="${glad_source_dir}/glad/glad.h" -DglDebug_inl="${glDebug_inl}" -P cmake/GenerateGlDebug.cmake
-    MAIN_DEPENDENCY "${glad_h}"
+    MAIN_DEPENDENCY "${glad_source_dir}/glad/glad.h"
     DEPENDS cmake/glDebug.inl.in cmake/GenerateGlDebug.cmake
     COMMENT "Generating glDebug.inl"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
The variable glad_h only exists in the generator script not the main file.
This made the compilation not pick up on any changes and update the file accordingly...