### PR TITLE
Clear updatable list on engine exit

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -67,6 +67,7 @@ Engine::Engine()
 
 Engine::~Engine()
 {
+    updatableList.clear();
     delete soundManager;
     soundManager = nullptr;
 }


### PR DESCRIPTION
Currently the updatables are destroyed *after* the engine (through statics destructions), which is too late.

(fixes the particles' buffers being destroyed after the context is gone, and probably a couple other minor issues)