### PR TITLE
Compatibility with gcc10

### DIFF
--- a/src/resources.h
+++ b/src/resources.h
@@ -38,8 +38,6 @@ public:
     
     virtual P<ResourceStream> getResourceStream(const string filename) override;
     virtual std::vector<string> findResources(const string searchPattern) override;
-private:
-    void findResources(std::vector<string>& paths, const string basepath, const string searchPattern);
 };
 
 P<ResourceStream> getResourceStream(const string filename);


### PR DESCRIPTION
GCC 10 seems to have a pretty... strict and  pedantic interpretation of the std fs spec, making calls like `is_directory("some_dir/")` fail.

Since we don't really handle complex cases or non directory path, just forego the test and go straight to the iterator which handles that better (for some reason).

fixes #195

cc @StarryWisdom if you want to double check this.