### PR TITLE
Use a condition_variable to abort waiting in the server scan thread

### DIFF
--- a/src/multiplayer_server_scanner.h
+++ b/src/multiplayer_server_scanner.h
@@ -5,6 +5,7 @@
 #include "multiplayer_server.h"
 #include <thread>
 #include <mutex>
+#include <condition_variable>
 
 
 //Class to find all servers that have the correct version number. Creates a big nice list.
@@ -32,6 +33,7 @@ private:
     string master_server_url;
     std::mutex server_list_mutex;
     std::thread master_server_scan_thread;
+    std::condition_variable abort_wait;
 
     std::function<void(sp::io::network::Address, string)> newServerCallback;
     std::function<void(sp::io::network::Address)> removedServerCallback;
@@ -39,6 +41,8 @@ public:
 
     ServerScanner(int version_number, int server_port = defaultServerPort);
     virtual ~ServerScanner();
+
+    virtual void destroy() override;
 
     virtual void update(float delta) override;
     void addCallbacks(std::function<void(sp::io::network::Address, string)> newServerCallback, std::function<void(sp::io::network::Address)> removedServerCallback);


### PR DESCRIPTION
Fixes [EmptyEpsilon#1693](https://github.com/daid/EmptyEpsilon/issues/1693)

This is my first contribution to a c++ project, much less working with threading in it. Both the places setting `isDestroyed` and `master_server_url` now notify the new `abort_wait` condition variable, so it shouldn't have to pause for the threads anymore.

Optimally, the get request should probably get a some abort mechanism, too. But at least when the server responds quickly, I now no longer get any framerate dips when switching between LAN and Internet in the server list.