### PR TITLE
Add missing #include <memory> to websocket.h

### DIFF
--- a/src/io/http/websocket.h
+++ b/src/io/http/websocket.h
@@ -5,6 +5,9 @@
 #include <io/network/tcpSocket.h>
 #include <unordered_map>
 
+#ifndef EMSCRIPTEN
+#include <memory>
+#endif
 
 namespace sp {
 namespace io {


### PR DESCRIPTION
std::unique_ptr, which is used for the 'socket' field, is defined in
<memory> but currently not included. Starting with GCC 12, the missing
include will cause a compilation error.

The missing include was found by Gentoo's CI and reported as
https://bugs.gentoo.org/846935