### PR TITLE
[engine] Handle SDL events even when no window is open

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -111,6 +111,16 @@ void Engine::runMainLoop()
         sp::SystemStopwatch frame_timer;
         while(running)
         {
+            // Handle SDL_QUIT event
+            SDL_Event event;
+            while (SDL_PollEvent(&event))
+            {
+                if (event.type == SDL_QUIT)
+                {
+                    running = false;
+                }
+            }
+
             float delta = frame_timer.restart();
             if (delta > 0.5f)
                 delta = 0.5f;


### PR DESCRIPTION
SDL events were handled only when `Window::all_windows.size() != 0`. This meant if there were no windows, SDL_QUIT events weren't handled. Since SDL intercepts SIGINT and converts it to SDL_QUIT, issue #1749 happened.

Add SDL_QUIT event handling to the headless event handling.

Fixes daid/EmptyEpsilon#1749.