### PR TITLE
[engine] Also run debug timer headless

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -109,8 +109,18 @@ void Engine::runMainLoop()
     if (Window::all_windows.size() == 0)
     {
         sp::SystemStopwatch frame_timer;
+#ifdef DEBUG
+        sp::SystemTimer debug_output_timer;
+        debug_output_timer.repeat(5);
+#endif
+
         while(running)
         {
+#ifdef DEBUG
+            if (debug_output_timer.isExpired())
+                LOG(DEBUG) << "Object count: " << DEBUG_PobjCount << " " << updatableList.size();
+#endif
+
             float delta = frame_timer.restart();
             if (delta > 0.5f)
                 delta = 0.5f;


### PR DESCRIPTION
The debug timer runs only if a window exists. Run it even when a window doesn't exist.