### PR TITLE
[#229] Fix logging priority list

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -24,7 +24,8 @@
 
 namespace
 {
-    const std::array<std::string, SDL_NUM_LOG_PRIORITIES - 1> priority_labels{
+    const std::array<std::string, SDL_NUM_LOG_PRIORITIES> priority_labels{
+        "[UNKNOWN ]: ",
         "[VERBOSE ]: ",
         "[DEBUG   ]: ",
         "[INFO    ]: ",


### PR DESCRIPTION
SDL_priority_prefixes has NULL as its first value, but SP's has VERBOSE. Passing SDL_LOG_PRIORITY_... values, which apparently expect a 1-indexed list, to SP's priority_labels list results in off-by-one behavior (fixes #229).

This adds an UNKNOWN first value to priority_labels to align with SDL_priority_prefixes.