### PR TITLE
[RenderTarget] Reduce atlas_size to 1k

### DIFF
--- a/src/graphics/renderTarget.cpp
+++ b/src/graphics/renderTarget.cpp
@@ -41,7 +41,7 @@ struct ImageInfo
 static sp::AtlasTexture* atlas_texture;
 static std::unordered_map<string, ImageInfo> image_info;
 static std::unordered_map<sp::Font*, std::unordered_map<int, Rect>> atlas_glyphs;
-static constexpr glm::ivec2 atlas_size = {2048, 2048};
+static constexpr glm::ivec2 atlas_size = {1024, 1024};
 static constexpr glm::vec2 atlas_white_pixel = {(float(atlas_size.x)-0.5f)/float(atlas_size.x), (float(atlas_size.y)-0.5f)/float(atlas_size.y)};
 
 


### PR DESCRIPTION
I don't know why, but reducing the atlas size fixes daid/EmptyEpsilon#1814 on Android, including newer devices that should be able to support a 2k texture size.

----

With this patch:

![Screenshot from 2023-04-05 00-04-29](https://user-images.githubusercontent.com/19192104/230007012-26d0aea5-3ae9-44fa-93e4-16c3b2b00a88.png)

Without this patch:

![Screenshot from 2023-04-05 00-13-08](https://user-images.githubusercontent.com/19192104/230007928-c747f7aa-036f-45fd-b32c-4794b334b024.png)

----

With this patch:

![Screenshot from 2023-04-05 00-04-16](https://user-images.githubusercontent.com/19192104/230007017-d7e63ec6-4e3f-4548-9f68-d867af1a5c3e.png)

Without this patch:

![Screenshot from 2023-04-05 00-11-51](https://user-images.githubusercontent.com/19192104/230007655-b1a248c0-9b17-4e18-9e16-80e697e21676.png)

----

With this patch:

![Screenshot from 2023-04-05 00-04-06](https://user-images.githubusercontent.com/19192104/230007022-4d2a571b-eb01-4936-a5ab-fd033aeaa1d2.png)

Without this patch:

![Screenshot from 2023-04-05 00-11-39](https://user-images.githubusercontent.com/19192104/230007660-ce1c5279-a14c-404d-b484-d1c01074975b.png)

----

With this patch:

![Screenshot from 2023-04-05 00-03-49](https://user-images.githubusercontent.com/19192104/230007026-ab93de45-db7e-4872-ac6c-94faf28fd2f1.png)

Without this patch:

![Screenshot from 2023-04-05 00-12-01](https://user-images.githubusercontent.com/19192104/230007652-ac1110ba-e2ba-4204-80ff-eff3db172151.png)

----



