### PR TITLE
[Shader] Conditionally use high-precision floats if available

### DIFF
--- a/src/graphics/shader.cpp
+++ b/src/graphics/shader.cpp
@@ -8,7 +8,7 @@ namespace sp {
 static Shader* current_shader = nullptr;
 
 static const char* vertex_shader_header_es = "#version 100\nprecision highp float;\n";
-static const char* fragment_shader_header_es = "#version 100\nprecision mediump float;\n";
+static const char* fragment_shader_header_es = "#version 100\n#ifdef GL_FRAGMENT_PRECISION_HIGH\nprecision highp float;\n#else\nprecision mediump float\n#endif\n";
 static const char* vertex_shader_header = "#version 120\n";
 static const char* fragment_shader_header = "#version 120\n";
 


### PR DESCRIPTION
Add a line to enable high-precision floats (`highp`) instead of medium-precision (`mediump`) if `GL_FRAGMENT_PRECISION_HIGH` is defined on OpenGL ES devices.

Results on a Nexus 6a running Android 13, with and without this patch, are the same as #234, so in that case this also fixes https://github.com/daid/EmptyEpsilon/issues/1814.

If a GLES device doesn't support `highp`, or if it does support it but doesn't define `GL_FRAGMENT_PRECISION_HIGH`, I don't expect this patch to change any behavior.