### PR TITLE
io/network/address.h: add missing cstdint include

### DIFF
--- a/src/io/network/address.h
+++ b/src/io/network/address.h
@@ -2,6 +2,7 @@
 #define SP2_IO_NETWORK_ADDRESS_H
 
 #include <stringImproved.h>
+#include <cstdint>
 #include <list>
 
 


### PR DESCRIPTION
With 9825f2d0659a ("minor fixes in network (#184)") the type of addr was changed from std::string to std::vector<uint8_t>, however the header for uint8_t was not included. This will cause a compile error starting with GCC 13.

Downstream Gentoo bug: https://bugs.gentoo.org/894738

Fixes: 9825f2d0659a ("minor fixes in network (#184)")