### PR TITLE
lua: fix underlinking

### DIFF
--- a/libs/lua/CMakeLists.txt
+++ b/libs/lua/CMakeLists.txt
@@ -41,6 +41,7 @@ target_include_directories(lua
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
+target_link_libraries(lua m)
 #--------------------------------Installation----------------------------------
 install(
 	TARGETS lua


### PR DESCRIPTION
lmathlib.c includes math.h and hence needs to be linked with -lm or otherwise I won't compile with GCC 13.