### PR TITLE
Correctly read Dash character (`-`) keybind from settings file

### DIFF
--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -70,7 +70,7 @@ void Keybinding::setKeys(const std::initializer_list<const string>& keys)
 
 void Keybinding::addKey(const string& key, bool inverted)
 {
-    if (key.startswith("-"))
+    if (key.startswith("-") && key.length() > 1)
     {
         return addKey(key.substr(1), !inverted);
     }


### PR DESCRIPTION
In game, you can set `-` as a keybind and it'll work fine. After exiting the game, the `keybindings.json` file has the keybind with `-` stored correctly. However when re-launching the game, the keybind is no longer assigned.

In `EmptyEpsilon.log`, there is a log message saying that the `-` character didn't get parsed correctly from the `keybindings.json` file. Note that there's no space (or any character) after the colon.

```log
[INFO    ]: Starting...
[INFO    ]: Crash Reporter ON
[INFO    ]: Using . as configuration path
[INFO    ]: Loaded: packs/Angryfly.pack with 166 files
[INFO    ]: Loaded: packs/Asteroids.pack with 30 files
[INFO    ]: Loaded: packs/msgamedev.pack with 96 files
[WARNING ]: Unknown key binding:
[INFO    ]: Loading treegui/default.theme.txt
```