### PR TITLE
Improve sandboxing setup; re-allow get/setmetatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ set(source_files #All SeriousProton's objects to compile
     src/resources.cpp
     src/scriptInterface.cpp
     src/scriptInterfaceMagic.cpp
+    src/scriptInterfaceSandbox.cpp
     src/shaderManager.cpp
     src/soundManager.cpp
     src/stringImproved.cpp
@@ -252,6 +253,7 @@ set(source_files #All SeriousProton's objects to compile
     src/resources.h
     src/scriptInterface.h
     src/scriptInterfaceMagic.h
+    src/scriptInterfaceSandbox.h
     src/shaderManager.h
     src/soundManager.h
     src/stringImproved.h

--- a/src/scriptInterface.cpp
+++ b/src/scriptInterface.cpp
@@ -108,6 +108,13 @@ static const luaL_Reg loadedlibs[] = {
   {NULL, NULL}
 };
 
+static const char* safe_functions[] = {
+    "assert", "error", "getmetatable", "ipairs", "next", "pairs", "pcall",
+    "print", "rawequal", "rawget", "rawlen", "rawset", "require", "select",
+    "setmetatable", "tonumber", "tostring", "type", "xpcall",
+    NULL,
+};
+
 void ScriptObject::createLuaState()
 {
     if (L == NULL)
@@ -119,43 +126,17 @@ void ScriptObject::createLuaState()
         {
             luaL_requiref(L, lib->name, lib->func, 1);
             lua_pop(L, 1);  /* remove lib */
-
-            // for any library that isn't the global base, it will have registered a table we need to make read-only
-            if (strcmp(lib->name, "_G")) {
-                lua_getglobal(L, lib->name);
-                makeReadonlyLuaProxy(L);
-                lua_setglobal(L, lib->name);
-            }
         }
 
-        //Remove unsafe base functions.
-        lua_pushnil(L);
-        lua_setglobal(L, "collectgarbage");
-        lua_pushnil(L);
-        lua_setglobal(L, "dofile");
-        lua_pushnil(L);
-        lua_setglobal(L, "loadfile");
-        lua_pushnil(L);
-        lua_setglobal(L, "load");
-        lua_pushnil(L);
-        lua_setglobal(L, "rawequal");
-
         // Protect the metatable the string library sets on strings.
-        // This metatable points to the global `string` library, rather than the environment's proxy.
+        // This metatable points to the global `string` library, rather than the environment's copy.
         // This global string library table can't be accessed directly, but it means a function defining
         // `function string.foo(...)` can't call that function as `"some_string":foo()` since the metatable
-        // points to the global version rather than its own editable proxy.
+        // points to the global version rather than its own copy.
         // TODO see if this can be fixed without breaking the sandbox. probably not.
         lua_pushstring(L, "");
         protectLuaMetatable(L);
         lua_pop(L, 1);
-
-        // Replace the standard _G with a read-only proxy.
-        // We'll set _G in the script's environment to be that environment to act more like Lua's _G, but if the script sets `_G = nil` it'll clear that and get whatever _G exists in the global table.
-        // This is also a useful place to store the protected version of the real global table so we can use that as __index for the script environment metatable.
-        lua_pushglobaltable(L);
-        makeReadonlyLuaProxy(L);
-        lua_setglobal(L, "_G");
     }
 
     //Setup a new table as the first upvalue. This will be used as "global" environment for the script. And thus will prevent global namespace polution.
@@ -166,35 +147,62 @@ void ScriptObject::createLuaState()
     lua_pushvalue(L, -2);
     lua_rawset(L, -3);
 
-    // Register proxies for the global libraries
-    // We've made the global libraries' tables read-only, but some scripts will want to do `table.foo = function(...) ... end` to add to the standard set.
-    // Give each script its own editable proxy with a metatable pointing at the global library (which itself is a readonly proxy, since setting this local proxy to nil would reveal the global one)
+    // Copy in the safe global functions.
+    for (const char **fn = safe_functions; *fn; fn++)
+    {
+        lua_pushstring(L, *fn);
+        lua_getglobal(L, *fn);
+        lua_settable(L, -3);
+    }
+
+    // Copy in the global libraries.
     for (const luaL_Reg *lib = loadedlibs; lib->func; lib++)
     {
         if (!strcmp(lib->name, "_G")) {
             continue;
         }
 
-        lua_pushstring(L, lib->name);
-        lua_getglobal(L, lib->name);
-        makeEditableLuaProxy(L);
-        lua_rawset(L, -3);
+        // Make a table for the library.
+        lua_newtable(L);              // [env] [local]
+
+        // Set it into the script environment.
+        lua_pushstring(L, lib->name); // [env] [local] [libname]
+        lua_pushvalue(L, -2);         // [env] [local] [libname] [local]
+        lua_settable(L, -4);          // [env] [local]
+
+        // Iterate the global library.
+        lua_getglobal(L, lib->name);  // [env] [local] [global]
+        lua_pushnil(L);               // [env] [local] [global] nil
+        while (lua_next(L, -2))
+        {                             // [env] [local] [global] [key] [value]
+            if (!lua_isfunction(L, -1) && !lua_isnumber(L, -1))
+            {
+                // This doesn't trigger on anything right now; it's here in case anything gets added to any of the libraries that would potentially break the sandbox.
+                LOG(WARNING) << "ignoring non-{function,number} in " << lib->name;
+                lua_pop(L, 1);
+                continue;
+            }
+
+            // Functions and numbers are safe to share - copy the value into the script's library table
+            lua_pushvalue(L, -2); // [env] [local] [global] [key] [value] [key]
+            lua_rotate(L, -2, 1); // [env] [local] [global] [key] [key] [value]
+            lua_settable(L, -5);  // [env] [local] [global] [key]
+        }
+                       // [env] [local] [global]
+        lua_pop(L, 2); // [env]
     }
 
     //Register all global functions for our game.
     for(ScriptClassInfo* item = scriptClassInfoList; item != NULL; item = item->next)
+    {
         item->register_function(L);
 
-    // Create a metatable for the script environment.
-    // Note that unlike all other metatables we set up, this metatable is _not_ protected.
-    // This is to allow the sandboxed code to set metatable bits on its own environment, since we don't let it wrap the actual table.
-    // This isn't a security issue since the only things it allows the script to do are 1) mess with its own environment, and 2) see the read-only global table proxy in __index
+        lua_pushstring(L, item->class_name.c_str());
+        lua_getglobal(L, item->class_name.c_str());
+        lua_settable(L, -3);
+    }
+
     // TODO: probably all non-script access to the environment table should be rawget/rawset so we don't have to worry about the sandboxed code doing something funky in __index/__newindex?
-    lua_newtable(L);
-    lua_pushstring(L, "__index");
-    lua_getglobal(L, "_G");
-    lua_rawset(L, -3);
-    lua_setmetatable(L, -2);
 
     //Register the destroyScript function. This needs a reference back to the script object, we pass this as an upvalue.
     lua_pushstring(L, "destroyScript");

--- a/src/scriptInterface.cpp
+++ b/src/scriptInterface.cpp
@@ -1,4 +1,5 @@
 #include <sys/stat.h>
+#include <cstring>
 
 #include "random.h"
 #include "resources.h"

--- a/src/scriptInterfaceMagic.h
+++ b/src/scriptInterfaceMagic.h
@@ -198,9 +198,6 @@ struct convert<P<T>>
             *p = new P<PObject>();
             (**p) = ptr;
 
-            // protect the new userdata's metatable
-            protectLuaMetatable(L);
-
             lua_rawset(L, -3);
 
             lua_pushlightuserdata(L, ptr);

--- a/src/scriptInterfaceMagic.h
+++ b/src/scriptInterfaceMagic.h
@@ -10,6 +10,7 @@
 #include "P.h"
 #include "stringImproved.h"
 #include "lua/lua.hpp"
+#include "scriptInterfaceSandbox.h"
 #include "glm/gtc/type_precision.hpp"
 #include <typeinfo>
 #include <optional>
@@ -196,6 +197,10 @@ struct convert<P<T>>
             P<PObject>** p = static_cast< P<PObject>** >(lua_newuserdata(L, sizeof(P<PObject>*)));
             *p = new P<PObject>();
             (**p) = ptr;
+
+            // protect the new userdata's metatable
+            protectLuaMetatable(L);
+
             lua_settable(L, -3);
 
             lua_pushlightuserdata(L, ptr);
@@ -598,6 +603,10 @@ public:
             lua_pop(L, 1);
             luaL_newmetatable(L, objectTypeName);
         }
+
+        lua_pushstring(L, "__metatable"); // protect the metatable
+        lua_pushstring(L, "sandbox");
+        lua_settable(L, metatable);
         
         lua_pushstring(L, "__gc");
         lua_pushcfunction(L, gc_collect);

--- a/src/scriptInterfaceMagic.h
+++ b/src/scriptInterfaceMagic.h
@@ -125,7 +125,7 @@ struct convert<T*>
             return;
         }
         lua_pushstring(L, "__ptr");
-        lua_gettable(L, idx++);
+        lua_rawget(L, idx++);
         
         P<PObject>** p = static_cast< P<PObject>** >(lua_touserdata(L, -1));
         lua_pop(L, 1);
@@ -154,7 +154,7 @@ struct convert<P<T>>
             return;
         }
         lua_pushstring(L, "__ptr");
-        lua_gettable(L, idx++);
+        lua_rawget(L, idx++);
         
         P<PObject>** p = static_cast< P<PObject>** >(lua_touserdata(L, -1));
         lua_pop(L, 1);
@@ -201,7 +201,7 @@ struct convert<P<T>>
             // protect the new userdata's metatable
             protectLuaMetatable(L);
 
-            lua_settable(L, -3);
+            lua_rawset(L, -3);
 
             lua_pushlightuserdata(L, ptr);
             lua_pushvalue(L, -2);
@@ -372,7 +372,7 @@ template<class T> struct call<T, ScriptCallback T::* >
         if (!lua_istable(L, -1))
             luaL_error(L, "??[setcallbackFunction] Upvalue 1 of function is not a table...");
         lua_pushstring(L, "__script_pointer");
-        lua_gettable(L, -2);
+        lua_rawget(L, -2);
         if (!lua_islightuserdata(L, -1))
             luaL_error(L, "??[setcallbackFunction] Cannot find reference back to script...");
         //Stack is now: [function_environment] [pointer]
@@ -528,7 +528,7 @@ public:
         if (!lua_istable(L, -1))
             return 0;
         lua_pushstring(L, "__ptr");
-        lua_gettable(L, -2);
+        lua_rawget(L, -2);
         if (lua_isuserdata(L, -1)) //When a subclass is destroyed, it's metatable might call the __gc function on it's sub-metatable. So we can get nil values here, ignore that.
         {
             PT* p = static_cast< PT* >(lua_touserdata(L, -1));

--- a/src/scriptInterfaceSandbox.cpp
+++ b/src/scriptInterfaceSandbox.cpp
@@ -1,0 +1,65 @@
+#include "lua/lua.hpp"
+#include "scriptInterfaceSandbox.h"
+
+int reject_write(lua_State* L) {
+    lua_pop(L, lua_gettop(L));
+    lua_pushstring(L, "cannot write to sandbox-external library");
+    lua_error(L);
+    return 0;
+}
+
+// Add or protect a metatable, and add that metatable to the stack.
+// Input Lua stack: [object]
+// Output Lua stack: [object] [mt]
+void protectGetLuaMetatable(lua_State* L)
+{
+    if (!lua_getmetatable(L, -1)) {
+        lua_newtable(L);         // [object] [mt]
+        lua_pushvalue(L, -1);    // [object] [mt] [mt]
+        lua_setmetatable(L, -3); // [object] [mt]
+    }
+
+    lua_pushstring(L, "__metatable"); // [object] [mt] "__metatable"
+    lua_pushstring(L, "sandbox");     // [object] [mt] "__metatable" "sandbox"
+    lua_settable(L, -3);              // [object] [mt]
+}
+
+void protectLuaMetatable(lua_State* L)
+{
+    protectGetLuaMetatable(L); // [object] [mt]
+    lua_pop(L, 1);             // [object]
+}
+
+// Make the base proxy for a table, and return the proxy and its metatable.
+// Input Lua stack: [table]
+// Output Lua stack: [proxy] [mt]
+void makeLuaProxy(lua_State* L)
+{
+    lua_newtable(L); // [table] [proxy]
+
+    // Add a protected metatable
+    protectGetLuaMetatable(L); // [table] [proxy] [mt]
+
+    // Set the metatable's __index to the original table
+    lua_pushstring(L, "__index"); // [table] [proxy] [mt] "__index"
+    lua_rotate(L, -4, -1);        // [proxy] [mt] "__index" [table]
+    lua_rawset(L, -3);            // [proxy] [mt]
+}
+
+void makeEditableLuaProxy(lua_State* L)
+{
+    makeLuaProxy(L); // [proxy] [mt]
+    lua_pop(L, 1);   // [proxy]
+}
+
+void makeReadonlyLuaProxy(lua_State* L)
+{
+    makeLuaProxy(L); // [proxy] [mt]
+
+    // Set the metatable's __newindex to reject writes
+    lua_pushstring(L, "__newindex");      // [proxy] [mt] "__newindex"
+    lua_pushcclosure(L, reject_write, 0); // [proxy] [mt] "__newindex" [reject_write]
+    lua_rawset(L, -3);                    // [proxy] [mt]
+
+    lua_pop(L, 1); // [proxy]
+}

--- a/src/scriptInterfaceSandbox.cpp
+++ b/src/scriptInterfaceSandbox.cpp
@@ -1,17 +1,10 @@
 #include "lua/lua.hpp"
 #include "scriptInterfaceSandbox.h"
 
-int reject_write(lua_State* L) {
-    lua_pop(L, lua_gettop(L));
-    lua_pushstring(L, "cannot write to sandbox-external library");
-    lua_error(L);
-    return 0;
-}
-
-// Add or protect a metatable, and add that metatable to the stack.
+// Add or protect a metatable for the provided object
 // Input Lua stack: [object]
-// Output Lua stack: [object] [mt]
-void protectGetLuaMetatable(lua_State* L)
+// Output Lua stack: [object]
+void protectLuaMetatable(lua_State* L)
 {
     if (!lua_getmetatable(L, -1)) {
         lua_newtable(L);         // [object] [mt]
@@ -22,44 +15,5 @@ void protectGetLuaMetatable(lua_State* L)
     lua_pushstring(L, "__metatable"); // [object] [mt] "__metatable"
     lua_pushstring(L, "sandbox");     // [object] [mt] "__metatable" "sandbox"
     lua_settable(L, -3);              // [object] [mt]
-}
-
-void protectLuaMetatable(lua_State* L)
-{
-    protectGetLuaMetatable(L); // [object] [mt]
-    lua_pop(L, 1);             // [object]
-}
-
-// Make the base proxy for a table, and return the proxy and its metatable.
-// Input Lua stack: [table]
-// Output Lua stack: [proxy] [mt]
-void makeLuaProxy(lua_State* L)
-{
-    lua_newtable(L); // [table] [proxy]
-
-    // Add a protected metatable
-    protectGetLuaMetatable(L); // [table] [proxy] [mt]
-
-    // Set the metatable's __index to the original table
-    lua_pushstring(L, "__index"); // [table] [proxy] [mt] "__index"
-    lua_rotate(L, -4, -1);        // [proxy] [mt] "__index" [table]
-    lua_rawset(L, -3);            // [proxy] [mt]
-}
-
-void makeEditableLuaProxy(lua_State* L)
-{
-    makeLuaProxy(L); // [proxy] [mt]
-    lua_pop(L, 1);   // [proxy]
-}
-
-void makeReadonlyLuaProxy(lua_State* L)
-{
-    makeLuaProxy(L); // [proxy] [mt]
-
-    // Set the metatable's __newindex to reject writes
-    lua_pushstring(L, "__newindex");      // [proxy] [mt] "__newindex"
-    lua_pushcclosure(L, reject_write, 0); // [proxy] [mt] "__newindex" [reject_write]
-    lua_rawset(L, -3);                    // [proxy] [mt]
-
-    lua_pop(L, 1); // [proxy]
+    lua_pop(L, 1);                    // [object]
 }

--- a/src/scriptInterfaceSandbox.cpp
+++ b/src/scriptInterfaceSandbox.cpp
@@ -14,6 +14,6 @@ void protectLuaMetatable(lua_State* L)
 
     lua_pushstring(L, "__metatable"); // [object] [mt] "__metatable"
     lua_pushstring(L, "sandbox");     // [object] [mt] "__metatable" "sandbox"
-    lua_settable(L, -3);              // [object] [mt]
+    lua_rawset(L, -3);                // [object] [mt]
     lua_pop(L, 1);                    // [object]
 }

--- a/src/scriptInterfaceSandbox.h
+++ b/src/scriptInterfaceSandbox.h
@@ -8,16 +8,4 @@
 // Output Lua stack: [object]
 void protectLuaMetatable(lua_State* L);
 
-// Create an editable proxy for the provided table.
-// The proxy table itself will be editable, but its metatable will be protected and the input table will not be directly accessible.
-// Input Lua stack: [table]
-// Output Lua stack: [proxy]
-void makeEditableLuaProxy(lua_State* L);
-
-// Create a read-only proxy for the provided table.
-// The proxy table will be empty and uneditable, its metatable will be protected, and the input table will not be directly accessible.
-// Input Lua stack: [table]
-// Output Lua stack: [proxy]
-void makeReadonlyLuaProxy(lua_State* L);
-
 #endif // SCRIPT_INTERFACE_SANDBOX_H

--- a/src/scriptInterfaceSandbox.h
+++ b/src/scriptInterfaceSandbox.h
@@ -1,0 +1,23 @@
+#ifndef SCRIPT_INTERFACE_SANDBOX_H
+#define SCRIPT_INTERFACE_SANDBOX_H
+
+#include "lua/lua.hpp"
+
+// Add or protect a metatable for the provided object such that the metatable can't be read or changed from inside the sandbox.
+// Input Lua stack: [object]
+// Output Lua stack: [object]
+void protectLuaMetatable(lua_State* L);
+
+// Create an editable proxy for the provided table.
+// The proxy table itself will be editable, but its metatable will be protected and the input table will not be directly accessible.
+// Input Lua stack: [table]
+// Output Lua stack: [proxy]
+void makeEditableLuaProxy(lua_State* L);
+
+// Create a read-only proxy for the provided table.
+// The proxy table will be empty and uneditable, its metatable will be protected, and the input table will not be directly accessible.
+// Input Lua stack: [table]
+// Output Lua stack: [proxy]
+void makeReadonlyLuaProxy(lua_State* L);
+
+#endif // SCRIPT_INTERFACE_SANDBOX_H


### PR DESCRIPTION
- Give each script its own proxy for global tables; this allows scripts to set e.g. `string.foo = ...` without affecting other scripts' view of the library.
- Protect all important metatables for values provided by C++
- Remove getmetatable and setmetatable from the list of disallowed functions