### PR TITLE
Fix shiplog window text

### DIFF
--- a/src/graphics/font.cpp
+++ b/src/graphics/font.cpp
@@ -215,7 +215,7 @@ glm::vec2 Font::PreparedFontString::getUsedAreaSize() const
     float max_y = 0.0f;
     for(auto& d : data) {
         max_x = std::max(max_x, d.position.x);
-        max_y = std::max(max_y, d.position.y);
+        max_y = std::max(max_y, (float(getLineCount()) + 0.3f) * d.size);
     }
 
     glm::vec2 result(max_x, max_y);


### PR DESCRIPTION
Fixed a bug in font rendering affecting GuiAdvancedScrollText. Using `d.position.y` returns the position within the bounding rectangle, so as additional lines are added, it causes additional blank lines to be added between them in an escalating progression causing huge gaps between log messages, overlaps, and a scrollbar that jumps around madly if not at the extreme top or bottom.

## Before
![BEFORE](https://github.com/user-attachments/assets/54826deb-fa4d-44ce-917c-b5d6d79b9cbe)

## After
![AFTER](https://github.com/user-attachments/assets/683758dd-8477-4823-8dad-c8e87a2b093d)
