### PR TITLE
implement __pairs for entity, entity_components, etc

### DIFF
--- a/src/script/environment.cpp
+++ b/src/script/environment.cpp
@@ -137,6 +137,47 @@ static int luaEntityNewIndex(lua_State* L) {
     return 0;
 }
 
+static int luaEntityPairsNext(lua_State* L) {
+    lua_settop(L, 2); // ensure we have a (possibly nil) key, as we may have been called with just (entity)
+
+    auto e = Convert<ecs::Entity>::fromLua(L, 1);
+    if (!e) return 0;
+
+    if (lua_type(L, 2) == LUA_TNIL) {
+        // nil => first call; return components first
+        lua_pop(L, 1);
+        lua_pushstring(L, "components");
+        *static_cast<ecs::Entity*>(lua_newuserdata(L, sizeof(ecs::Entity))) = e;
+        luaL_getmetatable(L, "entity_components");
+        lua_setmetatable(L, -2);
+        return 2;
+    }
+    if (lua_type(L, 2) == LUA_TSTRING && !strcmp(lua_tostring(L, 2), "components")) {
+        // second call, give lua_next a nil to get the first LTC key.
+        // from the third call onwards, we'll pass the previous key directly to lua_next.
+        lua_pop(L, 1);
+        lua_pushnil(L);
+    }
+
+    auto ltc = e.getComponent<LuaTableComponent>();
+    if (!ltc) return 0;
+
+    lua_rawgetp(L, LUA_REGISTRYINDEX, ltc);
+    lua_rotate(L, 2, -1);
+
+    return lua_next(L, -2) ? 2 : 0;
+}
+
+static int luaEntityPairs(lua_State* L) {
+    auto e = Convert<ecs::Entity>::fromLua(L, 1);
+    if (!e) return 0;
+
+    lua_pushcfunction(L, luaEntityPairsNext);
+    lua_pushvalue(L, -2);
+    lua_pushnil(L);
+    return 3;
+}
+
 static int luaEntityComponentsIndex(lua_State* L) {
     auto eptr = lua_touserdata(L, -2);
     if (!eptr) return 0;
@@ -232,6 +273,8 @@ lua_State* Environment::getLuaState()
         lua_setfield(L, -2, "__index");
         lua_pushcfunction(L, luaEntityNewIndex);
         lua_setfield(L, -2, "__newindex");
+        lua_pushcfunction(L, luaEntityPairs);
+        lua_setfield(L, -2, "__pairs");
         lua_pushcfunction(L, luaEntityEqual);
         lua_setfield(L, -2, "__eq");
         lua_pushstring(L, "sandboxed");


### PR DESCRIPTION
most of the implementations are just "make a table with all the values and delegate to `next`", with the exception of entity which is "return the components key then delegate to `next` with the LTC table".

if the C++ had a deterministically-ordered list of the keys, the functions could be smarter, but this works and the tables should be sufficiently temporary for it to not matter.