### PR TITLE
Improve detection of servers that go offline without notification

### DIFF
--- a/src/multiplayer_client.h
+++ b/src/multiplayer_client.h
@@ -19,6 +19,9 @@ extern P<GameClient> game_client;
 
 class GameClient : public Updatable
 {
+    // if the server doesn't send us any data for this long, send a packet to see if it's still there
+    constexpr static float heartbeat_time = 0.5;
+    // if the server doesn't send us any data for this long, disconnect
     constexpr static float no_data_disconnect_time = 20;
 public:
     std::vector<sp::ecs::Entity> entity_mapping;
@@ -52,6 +55,7 @@ private:
     int32_t client_id;
     Status status;
     sp::SystemTimer no_data_timeout;
+    sp::SystemTimer heartbeat_timer;
     NetworkAudioStreamManager audio_stream_manager;
 
     DisconnectReason disconnect_reason{ DisconnectReason::Unknown };

--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -423,7 +423,14 @@ void GameServer::update(float /*gameDelta*/)
                         {
                             clientList[n].ping = static_cast<int32_t>(clientList[n].round_trip_start_time.get() * 1000.0f);
                         }
-                    break;
+                        break;
+                    case CMD_ALIVE:
+                        {
+                            sp::io::DataBuffer response_packet;
+                            response_packet << CMD_ALIVE_RESP;
+                            clientList[n].socket->queue(response_packet);
+                        }
+                        break;
                     default:
                         LOG(ERROR) << "Unknown command from client: " << command;
                     }


### PR DESCRIPTION
before this PR:
- server stops sending packets
- socket gets closed (but the client doesn't notice)
- 20 seconds later the client goes "oh, I didn't get any packets for 20 seconds, the server probably broke" and disconnects

after this PR:
- server stops sending packets
- socket gets closed (client still doesn't notice)
- 0.5 seconds later the client goes "I didn't get any packets, I'll ask the server if it's still there", notices the closed socket, and disconnects

The existing 20-second timeout is retained for detecting the case where the socket remains open but the server is not responding, in which case waiting a little bit to see if it recovers is reasonable.