### PR TITLE
Measure font descenders

### DIFF
--- a/src/graphics/font.cpp
+++ b/src/graphics/font.cpp
@@ -58,6 +58,7 @@ void Font::PreparedFontString::append(std::string_view s, float text_size, glm::
             /*.string_offset =*/ int(string_offset + index),
             /*.size =*/ text_size,
             /*.color =*/ color,
+            /*.descender =*/ 0.0f,
         });
         previous_char_code = char_info.code;
         index += char_info.consumed_bytes;
@@ -74,8 +75,10 @@ void Font::PreparedFontString::append(std::string_view s, float text_size, glm::
         {
             glyph.advance = 0;
             glyph.bounds.size.x = 0;
+            glyph.descender = 0.0f;
         }
 
+        data.back().descender = glyph.descender * text_size / float(pixel_size);
         next_position_x += glyph.advance * text_size / float(pixel_size);
         if ((flags & FlagLineWrap) && next_position_x > area_size.x)
         {
@@ -126,6 +129,7 @@ void Font::PreparedFontString::finish()
             /*.string_offset =*/ 0,
             /*.size =*/ 0.0f,
             /*.color =*/ {255,255,255,255},
+            /*.descender =*/ 0.0f,
         });
     } else {
         data.push_back({
@@ -134,6 +138,7 @@ void Font::PreparedFontString::finish()
             /*.string_offset =*/ data.back().string_offset + 1,
             /*.size =*/ data.back().size,
             /*.color =*/ data.back().color,
+            /*.descender =*/ data.back().descender,
         });
     }
 
@@ -215,7 +220,7 @@ glm::vec2 Font::PreparedFontString::getUsedAreaSize() const
     float max_y = 0.0f;
     for(auto& d : data) {
         max_x = std::max(max_x, d.position.x);
-        max_y = std::max(max_y, d.position.y);
+        max_y = std::max(max_y, d.position.y + d.descender);
     }
 
     glm::vec2 result(max_x, max_y);

--- a/src/graphics/font.h
+++ b/src/graphics/font.h
@@ -29,6 +29,7 @@ public:
             int string_offset;
             float size;
             glm::u8vec4 color;
+            float descender;
         };
         std::vector<GlyphData> data;
 
@@ -65,6 +66,7 @@ public:
     public:
         Rect bounds;
         float advance;
+        float descender;
     };
     virtual CharacterInfo getCharacterInfo(const char* str) = 0;
     virtual bool getGlyphInfo(int char_code, int pixel_size, GlyphInfo& info) = 0;

--- a/src/graphics/freetypefont.cpp
+++ b/src/graphics/freetypefont.cpp
@@ -134,6 +134,7 @@ bool FreetypeFont::getGlyphInfo(int char_code, int pixel_size, Font::GlyphInfo& 
         
         info.bounds = Rect({0, 0}, {0, 0});
         info.advance = 0;
+        info.descender = 0.0f;
 
         if (static_cast<FT_Face>(ft_face)->size->metrics.x_ppem != pixel_size)
             FT_Set_Pixel_Sizes(static_cast<FT_Face>(ft_face), 0, pixel_size);
@@ -153,6 +154,7 @@ bool FreetypeFont::getGlyphInfo(int char_code, int pixel_size, Font::GlyphInfo& 
                 info.bounds.position.y = float(face->glyph->metrics.horiBearingY) / float(1 << 6);
                 info.bounds.size.x = float(face->glyph->metrics.width) / float(1 << 6);
                 info.bounds.size.y = float(face->glyph->metrics.height) / float(1 << 6);
+                info.descender = float(face->glyph->metrics.height - face->glyph->metrics.horiBearingY) / float(1 << 6);
                 
                 FT_Done_Glyph(glyph);
             }

--- a/src/graphics/renderTarget.cpp
+++ b/src/graphics/renderTarget.cpp
@@ -811,6 +811,7 @@ void RenderTarget::drawRotatedText(glm::vec2 center, float rotation, std::string
         {
             glyph.advance = 0.0f;
             glyph.bounds.size.x = 0.0f;
+            glyph.descender = 0.0f;
         }
 
         if (glyph.bounds.size.x > 0.0f)


### PR DESCRIPTION
To ensure that `Font::PreparedFontString::getUsedAreaSize()` returns an accurate value without changing glyph positions or line heights, track descenders using the delta between the glyph's `height` and its `horiBearingY` metric.

See https://freetype.org/freetype2/docs/tutorial/step2.html for context on the unreliability of descender metrics.