### PR TITLE
Fix issues that break MSVC strict compilation

### DIFF
--- a/src/container/sparseset.h
+++ b/src/container/sparseset.h
@@ -43,7 +43,7 @@ public:
             free_dense = new_free;
         } else {
             // Append to the data
-            sparse[index] = dense.size();
+            sparse[index] = static_cast<uint32_t>(dense.size());
             dense.push_back(index);
             data.emplace_back(value);
         }
@@ -67,7 +67,7 @@ public:
             free_dense = new_free;
         } else {
             // Append to the data
-            sparse[index] = dense.size();
+            sparse[index] = static_cast<uint32_t>(dense.size());
             dense.push_back(index);
             data.emplace_back(std::move(value));
         }

--- a/src/ecs/component.h
+++ b/src/ecs/component.h
@@ -23,6 +23,9 @@ protected:
 };
 
 template<typename T> class ComponentStorage : public ComponentStorageBase {
+public:
+    ComponentStorage() : ComponentStorageBase() {}
+private:
     void destroy(uint32_t index) override
     {
         sparseset.remove(index);
@@ -36,11 +39,12 @@ template<typename T> class ComponentStorage : public ComponentStorageBase {
 
     SparseSet<T> sparseset;
 
-    static inline ComponentStorage<T> storage;
+    static ComponentStorage<T> storage;
 
     friend class Entity;
     template<class, class...> friend class Query;
     friend class ComponentReplication<T>;
 };
 
+template<typename T> inline ComponentStorage<T> ComponentStorage<T>::storage{};
 }

--- a/src/multiplayer.cpp
+++ b/src/multiplayer.cpp
@@ -99,6 +99,10 @@ template <> void multiplayerReplicationFunctions<sp::ecs::Entity>::receiveData(v
         *e = sp::ecs::Entity{};
 }
 
+// Explicit template instantiation to ensure symbols are exported
+template void multiplayerReplicationFunctions<sp::ecs::Entity>::sendData(void*, sp::io::DataBuffer&);
+template void multiplayerReplicationFunctions<sp::ecs::Entity>::receiveData(void*, sp::io::DataBuffer&);
+
 void MultiplayerObject::sendClientCommand(sp::io::DataBuffer& packet)
 {
     if (game_server)

--- a/src/windowManager.cpp
+++ b/src/windowManager.cpp
@@ -1,6 +1,6 @@
 #include "windowManager.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "dynamicLibrary.h"
 
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
The `/permissive-` flag that appears in CMakeLists.txt seems to be ignored, discarded, or no-op on MSVC builds. The resulting errors block compilation.

- Add an explicit public default constructor to `ComponentStorage` to avoid `no appropriate default constructor available` errors
- Explicitly define the static inline `ComponentStorage` member named `storage`, instead of only declaring it, to avoid `use of undefined type 'sp::ecs::ComponentStorage<...>'` errors
- Use `_WIN32` instead of `WIN32` in preprocessor ifdefs; MSVC 18 doesn't appear to define `WIN32`
- Explicitly instantiate `multiplayerReplicationFunctions` templates
- Explicitly cast sparseset data to `uint32_t`

These changes should have no impact on non-MSVC builds, and would contribute toward unblocking MSVC as a compiler.