### PR TITLE
Fix mouse button edge cases

### DIFF
--- a/src/windowManager.cpp
+++ b/src/windowManager.cpp
@@ -500,6 +500,15 @@ void Window::handleEvent(const SDL_Event& event)
                 render_chain->onPointerLeave(-1);
             }
             break;
+        case SDL_WINDOWEVENT_FOCUS_LOST:
+            if (mouse_button_down_mask)
+            {
+                mouse_button_down_mask = 0;
+                int mx, my;
+                SDL_GetMouseState(&mx, &my);
+                render_chain->onPointerUp(mapPixelToCoords({mx, my}), sp::io::Pointer::mouse);
+            }
+            break;
         case SDL_WINDOWEVENT_CLOSE:
             //close();
             break;

--- a/src/windowManager.cpp
+++ b/src/windowManager.cpp
@@ -349,11 +349,9 @@ void Window::handleEvent(const SDL_Event& event)
         break;
     case SDL_MOUSEBUTTONUP:
         mouse_button_down_mask &=~(1 << int(event.button.button));
+        render_chain->onPointerUp(mapPixelToCoords({event.button.x, event.button.y}), sp::io::Pointer::mouse);
         if (!mouse_button_down_mask)
-        {
-            render_chain->onPointerUp(mapPixelToCoords({event.button.x, event.button.y}), sp::io::Pointer::mouse);
             render_chain->onPointerMove(mapPixelToCoords({event.button.x, event.button.y}), sp::io::Pointer::mouse);
-        }
         break;
     case SDL_MOUSEWHEEL:
         render_chain->onMouseWheelScroll(mapPixelToCoords({event.wheel.mouseX, event.wheel.mouseY}), event.wheel.preciseY);


### PR DESCRIPTION
Fix two edge cases that can result in a mouse button being read as down when it's up:

- Holding down multiple mouse buttons, then releasing one of them, doesn't fire onMouseUp because onMouseUp is sent only when no mouse buttons are held.

  For example, clicking and holding left mouse button on radar to set a heading, then also clicking and holding right button followed by releasing the left mouse button, leaves the left mouse button stuck in down state until the right mouse button is also released and left mouse button is clicked again.

   Always fire onMouseUp when a `SDL_MOUSEBUTTONUP` event is caught.

- Holding down a mouse button, then changing focus away from EE and then releasing it, doesn't capture the button being released and thus never fires onMouseUp, leaving the button stuck in down state.

   For example in windowed mode, clicking and holding on Helms radar to set a heading and then alt-tabbing to another window results in the button becoming stuck in down state and perpetually dragging until the mouse is clicked outside of the radar.

   Capture `SDL_WINDOWEVENT_FOCUS_LOST` events if window focus is lost while any button is held, and clear `mouse_button_down_mask` and fire `onPointerUp` using the last known mouse position.
