### PR TITLE
Refactor input to define hotkey interaction types

### DIFF
--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -288,6 +288,13 @@ Keybinding::Interaction Keybinding::getInteraction(int index) const
     return bindings[index].interaction;
 }
 
+void Keybinding::setInteraction(int index, Interaction i)
+{
+    if (index < 0 || index >= static_cast<int>(bindings.size()))
+        return;
+    bindings[index].interaction = i;
+}
+
 string Keybinding::keyNameForRaw(int key, bool inverted)
 {
     int data = key & ~type_mask;

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -723,8 +723,10 @@ void Keybinding::allPostUpdate()
         for (const auto& bind : keybinding->bindings)
         {
             if (bind.interaction == Interaction::Repeating)
+            {
                 has_repeating = true;
-            break;
+                break;
+            }
         }
         if (!has_repeating) continue;
 

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -20,6 +20,12 @@ Keybinding* Keybinding::rebinding_cancel_key = nullptr;
 Keybinding::Type Keybinding::rebinding_type;
 Keybinding::Interaction Keybinding::rebinding_interaction = Keybinding::Interaction::None;
 
+bool Keybinding::rebinding_preview_mode = false;
+Keybinding* Keybinding::rebinding_preview_target = nullptr;
+int Keybinding::rebinding_preview_key = 0;
+bool Keybinding::rebinding_preview_inverted = false;
+Keybinding::Interaction Keybinding::rebinding_preview_interaction = Keybinding::Interaction::None;
+
 float Keybinding::deadzone = 0.05f;
 float Keybinding::discrete_step_size = 0.1f;
 float Keybinding::threshold = 0.5f;
@@ -264,87 +270,89 @@ Keybinding::Interaction Keybinding::getInteraction(int index) const
     return bindings[index].interaction;
 }
 
+string Keybinding::keyNameForRaw(int key, bool inverted)
+{
+    int data = key & ~type_mask;
+    string sign = inverted ? "-" : "+";
+    switch(key & type_mask)
+    {
+    case keyboard_mask:
+        return SDL_GetKeyName(data);
+    case pointer_mask:
+        switch(Pointer::Button(data))
+        {
+        case Pointer::Button::Touch: return tr("pointer_input", "Touchscreen");
+        case Pointer::Button::Left: return tr("pointer_input", "Left button");
+        case Pointer::Button::Middle: return tr("pointer_input", "Middle button");
+        case Pointer::Button::Right: return tr("pointer_input", "Right button");
+        case Pointer::Button::X1: return tr("pointer_input", "X1 button");
+        case Pointer::Button::X2: return tr("pointer_input", "X2 button");
+        default: break;
+        }
+        break;
+    case joystick_axis_mask:
+        return tr("joystick_input", "Axis {number_plus_minus}").format({
+            {"number_plus_minus", string(data & 0xff) + sign}
+        });
+    case joystick_button_mask:
+        return tr("joystick_input", "Button {button_name}").format({
+            {"button_name", string(data & 0xff)}
+        });
+    case mouse_movement_mask:
+        switch(data)
+        {
+        case 0: return tr("mouse_input", "X axis{sign}").format({{"sign", sign}});
+        case 1: return tr("mouse_input", "Y axis{sign}").format({{"sign", sign}});
+        }
+        break;
+    case mouse_wheel_mask:
+        switch(data)
+        {
+        case 0: return tr("mouse_input", "Wheel sideways{sign}").format({{"sign", sign}});
+        case 1: return tr("mouse_input", "Wheel{sign}").format({{"sign", sign}});
+        }
+        break;
+    case game_controller_button_mask:
+        switch(data & 0xff)
+        {
+        case SDL_CONTROLLER_BUTTON_A: return "A";
+        case SDL_CONTROLLER_BUTTON_B: return "B";
+        case SDL_CONTROLLER_BUTTON_X: return "X";
+        case SDL_CONTROLLER_BUTTON_Y: return "Y";
+        case SDL_CONTROLLER_BUTTON_BACK: return tr("controller_input", "Back");
+        case SDL_CONTROLLER_BUTTON_GUIDE: return tr("controller_input", "Guide");
+        case SDL_CONTROLLER_BUTTON_START: return tr("controller_input", "Start");
+        case SDL_CONTROLLER_BUTTON_LEFTSTICK: return tr("controller_input_left", "L stick button");
+        case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return tr("controller_input_right", "R stick button");
+        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return tr("controller_input_left", "L shoulder");
+        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return tr("controller_input_right", "R shoulder");
+        case SDL_CONTROLLER_BUTTON_DPAD_UP: return tr("controller_input_dpad", "Pad up");
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return tr("controller_input_dpad", "Pad down");
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return tr("controller_input_dpad", "Pad left");
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return tr("controller_input_dpad", "Pad right");
+        }
+        break;
+    case game_controller_axis_mask:
+        switch(data & 0xff)
+        {
+        case SDL_CONTROLLER_AXIS_LEFTX: return tr("controller_input_left", "L stick X axis{sign}").format({{"sign", sign}});
+        case SDL_CONTROLLER_AXIS_LEFTY: return tr("controller_input_left", "L stick Y axis{sign}").format({{"sign", sign}});
+        case SDL_CONTROLLER_AXIS_RIGHTX: return tr("controller_input_right", "R stick X axis{sign}").format({{"sign", sign}});
+        case SDL_CONTROLLER_AXIS_RIGHTY: return tr("controller_input_right", "R stick Y axis{sign}").format({{"sign", sign}});
+        case SDL_CONTROLLER_AXIS_TRIGGERLEFT: return tr("controller_input_left", "L trigger{sign}").format({{"sign", sign}});
+        case SDL_CONTROLLER_AXIS_TRIGGERRIGHT: return tr("controller_input_right", "R trigger{sign}").format({{"sign", sign}});
+        }
+        break;
+    case virtual_mask:
+        return tr("virtual_input", "Virtual-{number}").format({{"number", string(data & 0xff)}});
+    }
+    return tr("unknown_input", "Unknown");
+}
+
 string Keybinding::getHumanReadableKeyName(int index) const
 {
     if (index >= 0 && index < static_cast<int>(bindings.size()))
-    {
-        int key = bindings[index].key;
-        int data = key & ~type_mask;
-        string sign = bindings[index].inverted ? "-" : "+";
-        switch(key & type_mask)
-        {
-        case keyboard_mask:
-            return SDL_GetKeyName(data);
-        case pointer_mask:
-            switch(Pointer::Button(data))
-            {
-            case Pointer::Button::Touch: return tr("pointer_input", "Touchscreen");
-            case Pointer::Button::Left: return tr("pointer_input", "Left button");
-            case Pointer::Button::Middle: return tr("pointer_input", "Middle button");
-            case Pointer::Button::Right: return tr("pointer_input", "Right button");
-            case Pointer::Button::X1: return tr("pointer_input", "X1 button");
-            case Pointer::Button::X2: return tr("pointer_input", "X2 button");
-            default: break;
-            }
-            break;
-        case joystick_axis_mask:
-            return tr("joystick_input", "Axis {number_plus_minus}").format({
-                {"number_plus_minus", string(data & 0xff) + sign}
-            });
-        case joystick_button_mask:
-            return tr("joystick_input", "Button {button_name}").format({
-                {"button_name", string(data & 0xff)}
-            });
-        case mouse_movement_mask:
-            switch(data)
-            {
-            case 0: return tr("mouse_input", "X axis{sign}").format({{"sign", sign}});
-            case 1: return tr("mouse_input", "Y axis{sign}").format({{"sign", sign}});
-            }
-            break;
-        case mouse_wheel_mask:
-            switch(data)
-            {
-            case 0: return tr("mouse_input", "Wheel sideways{sign}").format({{"sign", sign}});
-            case 1: return tr("mouse_input", "Wheel{sign}").format({{"sign", sign}});
-            }
-            break;
-        case game_controller_button_mask:
-            switch(data & 0xff)
-            {
-            case SDL_CONTROLLER_BUTTON_A: return "A";
-            case SDL_CONTROLLER_BUTTON_B: return "B";
-            case SDL_CONTROLLER_BUTTON_X: return "X";
-            case SDL_CONTROLLER_BUTTON_Y: return "Y";
-            case SDL_CONTROLLER_BUTTON_BACK: return tr("controller_input", "Back");
-            case SDL_CONTROLLER_BUTTON_GUIDE: return tr("controller_input", "Guide");
-            case SDL_CONTROLLER_BUTTON_START: return tr("controller_input", "Start");
-            case SDL_CONTROLLER_BUTTON_LEFTSTICK: return tr("controller_input_left", "L stick button");
-            case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return tr("controller_input_right", "R stick button");
-            case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return tr("controller_input_left", "L shoulder");
-            case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return tr("controller_input_right", "R shoulder");
-            case SDL_CONTROLLER_BUTTON_DPAD_UP: return tr("controller_input_dpad", "Pad up");
-            case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return tr("controller_input_dpad", "Pad down");
-            case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return tr("controller_input_dpad", "Pad left");
-            case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return tr("controller_input_dpad", "Pad right");
-            }
-            break;
-        case game_controller_axis_mask:
-            switch(data & 0xff)
-            {
-            case SDL_CONTROLLER_AXIS_LEFTX: return tr("controller_input_left", "L stick X axis{sign}").format({{"sign", sign}});
-            case SDL_CONTROLLER_AXIS_LEFTY: return tr("controller_input_left", "L stick Y axis{sign}").format({{"sign", sign}});
-            case SDL_CONTROLLER_AXIS_RIGHTX: return tr("controller_input_right", "R stick X axis{sign}").format({{"sign", sign}});
-            case SDL_CONTROLLER_AXIS_RIGHTY: return tr("controller_input_right", "R stick Y axis{sign}").format({{"sign", sign}});
-            case SDL_CONTROLLER_AXIS_TRIGGERLEFT: return tr("controller_input_left", "L trigger{sign}").format({{"sign", sign}});
-            case SDL_CONTROLLER_AXIS_TRIGGERRIGHT: return tr("controller_input_right", "R trigger{sign}").format({{"sign", sign}});
-            }
-            break;
-        case virtual_mask:
-            return tr("virtual_input", "Virtual-{number}").format({{"number", string(data & 0xff)}});
-        }
-        return tr("unknown_input", "Unknown");
-    }
+        return keyNameForRaw(bindings[index].key, bindings[index].inverted);
     return "";
 }
 
@@ -379,6 +387,7 @@ void Keybinding::cancelUserRebind()
 {
     rebinding_key = nullptr;
     rebinding_cancel_key = nullptr;
+    rebinding_preview_mode = false;
 }
 
 void Keybinding::setUserRebindCancelKey(Keybinding* cancel_key)
@@ -911,7 +920,18 @@ void Keybinding::handleEvent(const SDL_Event& event)
 
 void Keybinding::updateKeys(int key_number, float value)
 {
-    if (rebinding_key)
+    if (rebinding_preview_mode && rebinding_preview_target)
+    {
+        if ((value > threshold || value < -threshold) && (key_number & (static_cast<int>(rebinding_type) << 16)))
+        {
+            rebinding_preview_key = key_number;
+            rebinding_preview_inverted = value < 0.0f;
+            rebinding_preview_interaction = rebinding_interaction;
+            rebinding_preview_mode = false;
+            rebinding_key = nullptr;
+        }
+    }
+    else if (rebinding_key)
     {
         if ((value > threshold || value < -threshold) && (key_number & (static_cast<int>(rebinding_type) << 16)))
         {
@@ -945,6 +965,70 @@ void Keybinding::updateKeys(int key_number, float value)
                 bind.last_value = (fabs(v) < deadzone) ? 0.0f : v;
             }
         }
+    }
+}
+
+void Keybinding::startUserRebindPreview(Type bind_type, Interaction bind_interaction)
+{
+    rebinding_preview_target = this;
+    rebinding_preview_key = 0;
+    rebinding_preview_inverted = false;
+    rebinding_preview_interaction = bind_interaction;
+    rebinding_preview_mode = true;
+    rebinding_key = this;
+    rebinding_type = bind_type;
+    rebinding_interaction = bind_interaction;
+}
+
+bool Keybinding::hasPendingRebind() const
+{
+    return rebinding_preview_target == this && rebinding_preview_key != 0;
+}
+
+string Keybinding::getPendingRebindKeyName() const
+{
+    if (!hasPendingRebind()) return "";
+    return keyNameForRaw(rebinding_preview_key, rebinding_preview_inverted);
+}
+
+Keybinding::Type Keybinding::getPendingRebindKeyType() const
+{
+    if (!hasPendingRebind()) return Type::None;
+    return static_cast<Type>((rebinding_preview_key & type_mask) >> 16);
+}
+
+int Keybinding::getPendingRebindRawKey() const
+{
+    return hasPendingRebind() ? rebinding_preview_key : 0;
+}
+
+int Keybinding::getRawKeyNumber(int index) const
+{
+    if (index < 0 || index >= static_cast<int>(bindings.size())) return 0;
+    return bindings[index].key;
+}
+
+void Keybinding::setPendingRebindInteraction(Interaction interaction)
+{
+    if (rebinding_preview_target == this)
+        rebinding_preview_interaction = interaction;
+}
+
+void Keybinding::commitPendingRebind()
+{
+    if (!hasPendingRebind()) return;
+    addBinding(rebinding_preview_key, rebinding_preview_inverted, rebinding_preview_interaction);
+    rebinding_preview_key = 0;
+    rebinding_preview_target = nullptr;
+}
+
+void Keybinding::discardPendingRebind()
+{
+    if (rebinding_preview_target == this)
+    {
+        rebinding_preview_key = 0;
+        rebinding_preview_target = nullptr;
+        rebinding_preview_mode = false;
     }
 }
 

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -5,6 +5,7 @@
 #include <io/json.h>
 #include <fstream>
 #include <unordered_set>
+#include <algorithm>
 #include <SDL_events.h>
 
 
@@ -14,6 +15,7 @@ namespace io {
 Keybinding* Keybinding::keybindings = nullptr;
 Keybinding* Keybinding::rebinding_key = nullptr;
 Keybinding::Type Keybinding::rebinding_type;
+Keybinding::Interaction Keybinding::rebinding_interaction = Keybinding::Interaction::None;
 
 float Keybinding::deadzone = 0.05f;
 
@@ -244,9 +246,16 @@ string Keybinding::getKeyInternal(int index) const
 
 Keybinding::Type Keybinding::getKeyType(int index) const
 {
-    if (index < 0 || index >= int(bindings.size()))
+    if (index < 0 || index >= static_cast<int>(bindings.size()))
         return Type::None;
     return static_cast<Type>((bindings[index].key & type_mask) >> 16);
+}
+
+Keybinding::Interaction Keybinding::getInteraction(int index) const
+{
+    if (index < 0 || index >= static_cast<int>(bindings.size()))
+        return Interaction::None;
+    return bindings[index].interaction;
 }
 
 string Keybinding::getHumanReadableKeyName(int index) const
@@ -349,10 +358,11 @@ float Keybinding::getValue() const
     return value;
 }
 
-void Keybinding::startUserRebind(Type bind_type)
+void Keybinding::startUserRebind(Type bind_type, Interaction bind_interaction)
 {
     rebinding_key = this;
     rebinding_type = bind_type;
+    rebinding_interaction = bind_interaction;
 }
 
 bool Keybinding::isUserRebinding() const
@@ -399,7 +409,27 @@ void Keybinding::loadKeybindings(const string& filename)
             continue;
         if (entry["key"].is_string())
         {
-            keybinding->setKey(entry["key"].get<std::string>());
+            string key_str = entry["key"].get<std::string>();
+            Interaction inter = Interaction::None;
+            const std::vector<std::pair<string, Interaction>> interaction_names = {
+                {"Sustained", Interaction::Sustained},
+                {"Stepped",   Interaction::Stepped},
+                {"Axis0",     Interaction::Axis0},
+                {"Axis1",     Interaction::Axis1},
+            };
+            for (const auto& pair : interaction_names)
+            {
+                string suffix = ":" + pair.first;
+                if (key_str.endswith(suffix))
+                {
+                    key_str = key_str.substr(0, key_str.length() - suffix.length());
+                    inter = pair.second;
+                    break;
+                }
+            }
+            keybinding->setKey(key_str);
+            if (!keybinding->bindings.empty())
+                keybinding->bindings.back().interaction = inter;
         }
         else if (entry["key"].is_array())
         {
@@ -407,13 +437,39 @@ void Keybinding::loadKeybindings(const string& filename)
             for (const auto& key_entry : entry["key"])
             {
                 if (key_entry.is_string())
-                    keybinding->addKey(key_entry.get<std::string>());
+                {
+                    string key_str = key_entry.get<std::string>();
+                    Interaction inter = Interaction::None;
+                    const std::vector<std::pair<string, Interaction>> interaction_names = {
+                        {"Sustained", Interaction::Sustained},
+                        {"Stepped",   Interaction::Stepped},
+                        {"Axis0",     Interaction::Axis0},
+                        {"Axis1",     Interaction::Axis1},
+                    };
+                    for (const auto& pair : interaction_names)
+                    {
+                        string suffix = ":" + pair.first;
+                        if (key_str.endswith(suffix))
+                        {
+                            key_str = key_str.substr(0, key_str.length() - suffix.length());
+                            inter = pair.second;
+                            break;
+                        }
+                    }
+                    keybinding->addKey(key_str);
+                    if (!keybinding->bindings.empty())
+                        keybinding->bindings.back().interaction = inter;
+                }
             }
         }
         else
         {
             keybinding->bindings.clear();
         }
+        if (entry.contains("step") && entry["step"].is_number())
+            keybinding->step_size = entry["step"].get<float>();
+        if (entry.contains("sens") && entry["sens"].is_number())
+            keybinding->sensitivity = entry["sens"].get<float>();
     }
     LOG(Info, "Keybindings loaded from ", filename);
 }
@@ -426,8 +482,30 @@ void Keybinding::saveKeybindings(const string& filename)
         nlohmann::json data;
         nlohmann::json keys;
         for(unsigned int index=0; index<keybinding->bindings.size(); index++)
-            keys.push_back(keybinding->getKey(index).c_str());
+        {
+            string key_str = keybinding->getKey(index);
+            Interaction inter = keybinding->bindings[index].interaction;
+            if (inter != Interaction::None)
+            {
+                string interaction_name;
+                switch (inter)
+                {
+                case Interaction::Sustained: interaction_name = "Sustained"; break;
+                case Interaction::Stepped:   interaction_name = "Stepped"; break;
+                case Interaction::Axis0:     interaction_name = "Axis0"; break;
+                case Interaction::Axis1:     interaction_name = "Axis1"; break;
+                default: break;
+                }
+                if (!interaction_name.empty())
+                    key_str += ":" + interaction_name;
+            }
+            keys.push_back(key_str.c_str());
+        }
         data["key"] = keys;
+        if (keybinding->step_size != 0.1f)
+            data["step"] = keybinding->step_size;
+        if (keybinding->sensitivity != 1.0f)
+            data["sens"] = keybinding->sensitivity;
         obj[keybinding->name] = data;
     }
 
@@ -476,7 +554,7 @@ void Keybinding::setVirtualKey(int index, float value)
     updateKeys(virtual_mask | index, value);
 }
 
-void Keybinding::addBinding(int key, bool inverted)
+void Keybinding::addBinding(int key, bool inverted, Interaction interaction)
 {
     for(auto& bind : bindings)
     {
@@ -486,7 +564,40 @@ void Keybinding::addBinding(int key, bool inverted)
             return;
         }
     }
-    bindings.push_back({key, inverted});
+    bindings.push_back({key, inverted, interaction});
+}
+
+void Keybinding::setValue(float new_value, int key_type, Interaction bind_interaction, float prev_bind_value)
+{
+    // Run existing per-key threshold/event logic first (delegate to 2-param overload).
+    setValue(new_value, key_type);
+
+    // Per-interaction state update.
+    float threshold_value = fabs(new_value);
+    if (threshold_value < deadzone)
+        threshold_value = 0.0f;
+    float prev_threshold = fabs(prev_bind_value);
+    if (prev_threshold < deadzone)
+        prev_threshold = 0.0f;
+
+    switch (bind_interaction)
+    {
+    case Interaction::Sustained:
+        sustained_value = new_value;
+        break;
+    case Interaction::Stepped:
+        if (prev_threshold < threshold && threshold_value >= threshold) stepped_down = true;
+        if (prev_threshold >= threshold && threshold_value < threshold) stepped_up = true;
+        break;
+    case Interaction::Axis0:
+        axis0_value = std::clamp(new_value, 0.0f, 1.0f);
+        break;
+    case Interaction::Axis1:
+        axis1_value = new_value;
+        break;
+    default:
+        break;
+    }
 }
 
 void Keybinding::setValue(float new_value, int key_type)
@@ -521,6 +632,9 @@ void Keybinding::postUpdate()
         down_event = false;
     else if (up_event)
         up_event = false;
+
+    stepped_down = false;
+    stepped_up = false;
 }
 
 static int release_mouse = 0;
@@ -723,21 +837,20 @@ void Keybinding::updateKeys(int key_number, float value)
     {
         if ((value > threshold || value < -threshold) && (key_number & (static_cast<int>(rebinding_type) << 16)))
         {
-            rebinding_key->addBinding(key_number, value < 0.0f);
+            rebinding_key->addBinding(key_number, value < 0.0f, rebinding_interaction);
             rebinding_key = nullptr;
         }
     }
 
     for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
     {
-        for(const auto& bind : keybinding->bindings)
+        for(auto& bind : keybinding->bindings)
         {
             if (bind.key == key_number)
             {
-                if (bind.inverted)
-                    keybinding->setValue(-value, key_number);
-                else
-                    keybinding->setValue(value, key_number);
+                float v = bind.inverted ? -value : value;
+                keybinding->setValue(v, key_number, bind.interaction, bind.last_value);
+                bind.last_value = (fabs(v) < deadzone) ? 0.0f : v;
             }
         }
     }
@@ -751,6 +864,16 @@ bool operator&(const Keybinding::Type a, const Keybinding::Type b)
 Keybinding::Type operator|(const Keybinding::Type a, const Keybinding::Type b)
 {
     return static_cast<Keybinding::Type>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+bool operator&(Keybinding::Interaction a, Keybinding::Interaction b)
+{
+    return static_cast<int>(a) & static_cast<int>(b);
+}
+
+Keybinding::Interaction operator|(Keybinding::Interaction a, Keybinding::Interaction b)
+{
+    return static_cast<Keybinding::Interaction>(static_cast<int>(a) | static_cast<int>(b));
 }
 
 }//namespace io

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -16,6 +16,7 @@ namespace io {
 
 Keybinding* Keybinding::keybindings = nullptr;
 Keybinding* Keybinding::rebinding_key = nullptr;
+Keybinding* Keybinding::rebinding_cancel_key = nullptr;
 Keybinding::Type Keybinding::rebinding_type;
 Keybinding::Interaction Keybinding::rebinding_interaction = Keybinding::Interaction::None;
 
@@ -377,6 +378,12 @@ void Keybinding::startUserRebind(Type bind_type, Interaction bind_interaction)
 void Keybinding::cancelUserRebind()
 {
     rebinding_key = nullptr;
+    rebinding_cancel_key = nullptr;
+}
+
+void Keybinding::setUserRebindCancelKey(Keybinding* cancel_key)
+{
+    rebinding_cancel_key = cancel_key;
 }
 
 bool Keybinding::isUserRebinding() const
@@ -908,8 +915,22 @@ void Keybinding::updateKeys(int key_number, float value)
     {
         if ((value > threshold || value < -threshold) && (key_number & (static_cast<int>(rebinding_type) << 16)))
         {
-            rebinding_key->addBinding(key_number, value < 0.0f, rebinding_interaction);
+            bool cancelled = false;
+            if (rebinding_cancel_key)
+            {
+                for (auto& bind : rebinding_cancel_key->bindings)
+                {
+                    if (bind.key == key_number)
+                    {
+                        cancelled = true;
+                        break;
+                    }
+                }
+            }
+            if (!cancelled)
+                rebinding_key->addBinding(key_number, value < 0.0f, rebinding_interaction);
             rebinding_key = nullptr;
+            rebinding_cancel_key = nullptr;
         }
     }
 

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -194,6 +194,18 @@ void Keybinding::clearKeys()
     bindings.clear();
 }
 
+bool Keybinding::getKeyInverted(int index) const
+{
+    if (index < 0 || index >= static_cast<int>(bindings.size())) return false;
+    return bindings[index].inverted;
+}
+
+void Keybinding::setKeyInverted(int index, bool inverted)
+{
+    if (index < 0 || index >= static_cast<int>(bindings.size())) return;
+    bindings[index].inverted = inverted;
+}
+
 Keybinding::Interaction Keybinding::getDefaultInteraction(Type type) const
 {
     auto it = type_default_interactions.find(static_cast<int>(type));
@@ -680,10 +692,10 @@ void Keybinding::setValue(float new_value, int key_type)
         new_value = 0.0f;
     }
 
-    // Transition between keydown/up only for buttons and non-movement axes.
+    // Transition between keydown/up.
     // Can't avoid game_controller axes because some have axes on buttons and
-    // triggers.
-    if ((key_type & type_mask) != mouse_movement_mask && (key_type & type_mask) != joystick_axis_mask)
+    // triggers. Joystick axes also generate down/up events on threshold crossings.
+    if ((key_type & type_mask) != mouse_movement_mask)
     {
         if (this->value < threshold && threshold_value >= threshold) down_event = true;
         if (this->value >= threshold && threshold_value < threshold) up_event = true;
@@ -1023,6 +1035,17 @@ void Keybinding::setPendingRebindInteraction(Interaction interaction)
 {
     if (rebinding_preview_target == this)
         rebinding_preview_interaction = interaction;
+}
+
+bool Keybinding::getPendingRebindInverted() const
+{
+    return (rebinding_preview_target == this) ? rebinding_preview_inverted : false;
+}
+
+void Keybinding::setPendingRebindInverted(bool inverted)
+{
+    if (rebinding_preview_target == this)
+        rebinding_preview_inverted = inverted;
 }
 
 void Keybinding::commitPendingRebind()

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -1,4 +1,5 @@
 #include <io/keybinding.h>
+#include <i18n.h>
 #include <logging.h>
 #include <SDL_assert.h>
 #include <engine.h>
@@ -32,12 +33,11 @@ Keybinding::Keybinding(const string& name)
     down_event = false;
     up_event = false;
 
-    for(auto other = keybindings; other; other = other->next)
-        SDL_assert(other->name != name);//"Duplicate keybinding name"
+    for (auto other = keybindings; other; other = other->next)
+        SDL_assert(other->name != name); // "Duplicate keybinding name"
 
     auto ptr = &keybindings;
-    while(*ptr)
-        ptr = &((*ptr)->next);
+    while (*ptr) ptr = &((*ptr)->next);
     *ptr = this;
 }
 
@@ -60,9 +60,10 @@ Keybinding::Keybinding(const string& name, const std::initializer_list<const str
 
 Keybinding::~Keybinding()
 {
-    for(auto ptr = &keybindings; *ptr; ptr = &((*ptr)->next))
+    for (auto ptr = &keybindings; *ptr; ptr = &((*ptr)->next))
     {
-        if (*ptr == this) {
+        if (*ptr == this)
+        {
             *ptr = next;
             break;
         }
@@ -78,19 +79,17 @@ void Keybinding::setKey(const string& key)
 void Keybinding::setKeys(const std::initializer_list<const string>& keys)
 {
     bindings.clear();
-    for(const string& key : keys)
-        addKey(key);
+    for (const string& key : keys) addKey(key);
 }
 
 void Keybinding::addKey(const string& key, bool inverted)
 {
     if (key.startswith("-") && key.length() > 1)
-    {
         return addKey(key.substr(1), !inverted);
-    }
-    //Format for joystick keys:
-    //joy:[joystick_id]:axis:[axis_id]
-    //joy:[joystick_id]:button:[button_id]
+
+    // Format for joystick keys:
+    // joy:[joystick_id]:axis:[axis_id]
+    // joy:[joystick_id]:button:[button_id]
     if (key.startswith("joy:"))
     {
         std::vector<string> parts = key.split(":");
@@ -98,18 +97,19 @@ void Keybinding::addKey(const string& key, bool inverted)
         {
             int joystick_id = parts[1].toInt();
             int axis_button_id = parts[3].toInt();
+
             if (parts[2] == "axis")
-                addBinding(int(axis_button_id) | int(joystick_id) << 8 | joystick_axis_mask, inverted);
+                addBinding(axis_button_id | joystick_id << 8 | joystick_axis_mask, inverted);
             else if (parts[2] == "button")
-                addBinding(int(axis_button_id) | int(joystick_id) << 8 | joystick_button_mask, inverted);
-            else
-                LOG(Warning, "Unknown joystick binding:", key);
+                addBinding(axis_button_id | joystick_id << 8 | joystick_button_mask, inverted);
+            else LOG(Warning, "Unknown joystick binding:", key);
         }
         return;
     }
-    //Format for gamecontroller keys:
-    //gamecontroller:[joystick_id]:axis:[axis_name]
-    //gamecontroller:[joystick_id]:button:[button_name]
+
+    // Format for gamecontroller keys:
+    // gamecontroller:[joystick_id]:axis:[axis_name]
+    // gamecontroller:[joystick_id]:button:[button_name]
     if (key.startswith("gamecontroller:"))
     {
         std::vector<string> parts = key.split(":");
@@ -136,18 +136,17 @@ void Keybinding::addKey(const string& key, bool inverted)
                 }
                 addBinding(button | int(controller_id) << 8 | game_controller_button_mask, inverted);
             }
-            else
-            {
-                LOG(Warning, "Unknown game controller binding:", key);
-            }
+            else LOG(Warning, "Unknown game controller binding:", key);
         }
         return;
     }
+
     if (key.startswith("pointer:"))
     {
         addBinding(pointer_mask | key.substr(8).toInt(), inverted);
         return;
     }
+
     if (key.startswith("mouse:"))
     {
         if (key == "mouse:x") addBinding(mouse_movement_mask | 0, inverted);
@@ -155,6 +154,7 @@ void Keybinding::addKey(const string& key, bool inverted)
         else LOG(Warning, "Unknown mouse movement binding:", key);
         return;
     }
+
     if (key.startswith("wheel:"))
     {
         if (key == "wheel:x") addBinding(mouse_wheel_mask | 0, inverted);
@@ -162,6 +162,7 @@ void Keybinding::addKey(const string& key, bool inverted)
         else LOG(Warning, "Unknown mouse wheel binding:", key);
         return;
     }
+
     if (key.startswith("virtual:"))
     {
         int index = key.substr(8).toInt();
@@ -170,16 +171,14 @@ void Keybinding::addKey(const string& key, bool inverted)
     }
 
     SDL_Keycode code = SDL_GetKeyFromName(key.c_str());
-    if (code != SDLK_UNKNOWN)
-        addBinding(code | keyboard_mask, inverted);
-    else
-        LOG(Warning, "Unknown key binding:", key);
+    if (code != SDLK_UNKNOWN) addBinding(code | keyboard_mask, inverted);
+    else LOG(Warning, "Unknown key binding:", key);
 }
 
 void Keybinding::removeKey(int index)
 {
-    if (index < 0 || index >= int(bindings.size()))
-        return;
+    if (index < 0 || index >= int(bindings.size())) return;
+
     bindings.erase(bindings.begin() + index);
 }
 
@@ -202,19 +201,19 @@ string Keybinding::getKey(int index) const
 {
     if (index >= 0 && index < int(bindings.size()))
     {
-        if (bindings[index].inverted)
-            return "-" + getKeyInternal(index);
+        if (bindings[index].inverted) return "-" + getKeyInternal(index);
         return getKeyInternal(index);
     }
+
     return "";
 }
 
 string Keybinding::getKeyInternal(int index) const
 {
-    if (index >= 0 && index < int(bindings.size()))
+    if (index >= 0 && index < static_cast<int>(bindings.size()))
     {
         int key = bindings[index].key;
-        switch(key & type_mask)
+        switch (key & type_mask)
         {
         case keyboard_mask:
             return SDL_GetKeyName(key & ~type_mask);
@@ -266,7 +265,7 @@ Keybinding::Interaction Keybinding::getInteraction(int index) const
 
 string Keybinding::getHumanReadableKeyName(int index) const
 {
-    if (index >= 0 && index < int(bindings.size()))
+    if (index >= 0 && index < static_cast<int>(bindings.size()))
     {
         int key = bindings[index].key;
         int data = key & ~type_mask;
@@ -278,31 +277,35 @@ string Keybinding::getHumanReadableKeyName(int index) const
         case pointer_mask:
             switch(Pointer::Button(data))
             {
-            case Pointer::Button::Touch: return "Touch Screen";
-            case Pointer::Button::Left: return "Left Button";
-            case Pointer::Button::Middle: return "Middle Button";
-            case Pointer::Button::Right: return "Right Button";
-            case Pointer::Button::X1: return "X1 Button";
-            case Pointer::Button::X2: return "X2 Button";
+            case Pointer::Button::Touch: return tr("pointer_input", "Touchscreen");
+            case Pointer::Button::Left: return tr("pointer_input", "Left button");
+            case Pointer::Button::Middle: return tr("pointer_input", "Middle button");
+            case Pointer::Button::Right: return tr("pointer_input", "Right button");
+            case Pointer::Button::X1: return tr("pointer_input", "X1 button");
+            case Pointer::Button::X2: return tr("pointer_input", "X2 button");
             default: break;
             }
             break;
         case joystick_axis_mask:
-            return "Axis " + string(data & 0xff) + sign;
+            return tr("joystick_input", "Axis {number_plus_minus}").format({
+                {"number_plus_minus", string(data & 0xff) + sign}
+            });
         case joystick_button_mask:
-            return "Button " + string(data & 0xff);
+            return tr("joystick_input", "Button {button_name}").format({
+                {"button_name", string(data & 0xff)}
+            });
         case mouse_movement_mask:
             switch(data)
             {
-            case 0: return "Mouse X" + sign;
-            case 1: return "Mouse Y" + sign;
+            case 0: return tr("mouse_input", "X axis{sign}").format({{"sign", sign}});
+            case 1: return tr("mouse_input", "Y axis{sign}").format({{"sign", sign}});
             }
             break;
         case mouse_wheel_mask:
             switch(data)
             {
-            case 0: return "Wheel Sideways" + sign;
-            case 1: return "Wheel" + sign;
+            case 0: return tr("mouse_input", "Wheel sideways{sign}").format({{"sign", sign}});
+            case 1: return tr("mouse_input", "Wheel{sign}").format({{"sign", sign}});
             }
             break;
         case game_controller_button_mask:
@@ -312,34 +315,34 @@ string Keybinding::getHumanReadableKeyName(int index) const
             case SDL_CONTROLLER_BUTTON_B: return "B";
             case SDL_CONTROLLER_BUTTON_X: return "X";
             case SDL_CONTROLLER_BUTTON_Y: return "Y";
-            case SDL_CONTROLLER_BUTTON_BACK: return "Back";
-            case SDL_CONTROLLER_BUTTON_GUIDE: return "Guide";
-            case SDL_CONTROLLER_BUTTON_START: return "Start";
-            case SDL_CONTROLLER_BUTTON_LEFTSTICK: return "LeftStick";
-            case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return "RightStick";
-            case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return "LeftShoulder";
-            case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return "RightShoulder";
-            case SDL_CONTROLLER_BUTTON_DPAD_UP: return "Up";
-            case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return "Down";
-            case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return "Left";
-            case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return "Right";
+            case SDL_CONTROLLER_BUTTON_BACK: return tr("controller_input", "Back");
+            case SDL_CONTROLLER_BUTTON_GUIDE: return tr("controller_input", "Guide");
+            case SDL_CONTROLLER_BUTTON_START: return tr("controller_input", "Start");
+            case SDL_CONTROLLER_BUTTON_LEFTSTICK: return tr("controller_input_left", "L stick button");
+            case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return tr("controller_input_right", "R stick button");
+            case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return tr("controller_input_left", "L shoulder");
+            case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return tr("controller_input_right", "R shoulder");
+            case SDL_CONTROLLER_BUTTON_DPAD_UP: return tr("controller_input_dpad", "Pad up");
+            case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return tr("controller_input_dpad", "Pad down");
+            case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return tr("controller_input_dpad", "Pad left");
+            case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return tr("controller_input_dpad", "Pad right");
             }
             break;
         case game_controller_axis_mask:
             switch(data & 0xff)
             {
-            case SDL_CONTROLLER_AXIS_LEFTX: return "X Axis" + sign;
-            case SDL_CONTROLLER_AXIS_LEFTY: return "Y Axis" + sign;
-            case SDL_CONTROLLER_AXIS_RIGHTX: return "X Axis Right" + sign;
-            case SDL_CONTROLLER_AXIS_RIGHTY: return "Y Axis Right" + sign;
-            case SDL_CONTROLLER_AXIS_TRIGGERLEFT: return "Trigger Axis Left" + sign;
-            case SDL_CONTROLLER_AXIS_TRIGGERRIGHT: return "Trigger Axis Right" + sign;
+            case SDL_CONTROLLER_AXIS_LEFTX: return tr("controller_input_left", "L stick X axis{sign}").format({{"sign", sign}});
+            case SDL_CONTROLLER_AXIS_LEFTY: return tr("controller_input_left", "L stick Y axis{sign}").format({{"sign", sign}});
+            case SDL_CONTROLLER_AXIS_RIGHTX: return tr("controller_input_right", "R stick X axis{sign}").format({{"sign", sign}});
+            case SDL_CONTROLLER_AXIS_RIGHTY: return tr("controller_input_right", "R stick Y axis{sign}").format({{"sign", sign}});
+            case SDL_CONTROLLER_AXIS_TRIGGERLEFT: return tr("controller_input_left", "L trigger{sign}").format({{"sign", sign}});
+            case SDL_CONTROLLER_AXIS_TRIGGERRIGHT: return tr("controller_input_right", "R trigger{sign}").format({{"sign", sign}});
             }
             break;
         case virtual_mask:
-            return "Virtual-" + string(data & 0xff);
+            return tr("virtual_input", "Virtual-{number}").format({{"number", string(data & 0xff)}});
         }
-        return "Unknown";
+        return tr("unknown_input", "Unknown");
     }
     return "";
 }
@@ -384,17 +387,15 @@ int Keybinding::joystickCount()
 int Keybinding::gamepadCount()
 {
     int count = 0;
-    for(int n=0; n<SDL_NumJoysticks(); n++)
-        if (SDL_IsGameController(n))
-            count += 1;
+    for (int n = 0; n < SDL_NumJoysticks(); n++)
+        if (SDL_IsGameController(n)) count += 1;
     return count;
 }
 
 void Keybinding::loadKeybindings(const string& filename)
 {
     std::ifstream file(filename);
-    if (!file.is_open())
-        return;
+    if (!file.is_open()) return;
     std::stringstream data;
     data << file.rdbuf();
     std::string err;
@@ -539,9 +540,8 @@ void Keybinding::saveKeybindings(const string& filename)
 
 Keybinding* Keybinding::getByName(const string& name)
 {
-    for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
-        if (keybinding->name == name)
-            return keybinding;
+    for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
+        if (keybinding->name == name) return keybinding;
     return nullptr;
 }
 
@@ -549,10 +549,9 @@ std::vector<string> Keybinding::getCategories()
 {
     std::vector<string> result;
     std::unordered_set<string> found;
-    for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
+    for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
     {
-        if (found.find(keybinding->getCategory()) != found.end())
-            continue;
+        if (found.find(keybinding->getCategory()) != found.end()) continue;
         found.insert(keybinding->getCategory());
         result.push_back(keybinding->getCategory());
     }
@@ -562,24 +561,22 @@ std::vector<string> Keybinding::getCategories()
 std::vector<Keybinding*> Keybinding::listAllByCategory(const string& category)
 {
     std::vector<Keybinding*> result;
-    for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
-    {
-        if (keybinding->getCategory() == category)
-            result.push_back(keybinding);
-    }
+    for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
+        if (keybinding->getCategory() == category) result.push_back(keybinding);
+
     return result;
 }
 
 void Keybinding::setVirtualKey(int index, float value)
 {
-    SDL_assert(index >= 0 && index <= 255);//"Virtual key indexes need to be in the range 0-255"
-    
+    SDL_assert(index >= 0 && index <= 255); // "Virtual key indices need to be in the range 0-255"
+
     updateKeys(virtual_mask | index, value);
 }
 
 void Keybinding::addBinding(int key, bool inverted, Interaction interaction)
 {
-    for(auto& bind : bindings)
+    for (auto& bind : bindings)
     {
         if (bind.key == key)
         {
@@ -670,10 +667,8 @@ void Keybinding::setValue(float new_value, int key_type)
 
 void Keybinding::postUpdate()
 {
-    if (down_event)
-        down_event = false;
-    else if (up_event)
-        up_event = false;
+    if (down_event) down_event = false;
+    else if (up_event) up_event = false;
 
     discrete_step_down = false;
     discrete_step_up = false;
@@ -684,22 +679,31 @@ static int release_mouse = 0;
 
 void Keybinding::allPostUpdate()
 {
-    for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
+    // Update keybinds.
+    for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
         keybinding->postUpdate();
 
+    // Tick clock.
     unsigned int now = SDL_GetTicks();
+
+    // Repeat repeating binds.
     for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
     {
-        if (keybinding->repeat_hold_ticks == 0)
-            continue;
+        if (keybinding->repeat_hold_ticks == 0) continue;
+
         bool has_repeating = false;
         for (const auto& bind : keybinding->bindings)
-            if (bind.interaction == Interaction::Repeating) { has_repeating = true; break; }
-        if (!has_repeating)
-            continue;
+        {
+            if (bind.interaction == Interaction::Repeating)
+                has_repeating = true;
+            break;
+        }
+        if (!has_repeating) continue;
+
         const unsigned int wait = keybinding->repeat_started
             ? repeat_interval
             : repeat_delay + repeat_interval;
+
         if (now - keybinding->repeat_hold_ticks >= wait)
         {
             keybinding->repeat_ready = true;
@@ -708,15 +712,12 @@ void Keybinding::allPostUpdate()
         }
     }
 
-    if (release_mouse & (1 << 0))
-        updateKeys(0 | mouse_wheel_mask, 0.0);
-    if (release_mouse & (1 << 1))
-        updateKeys(1 | mouse_wheel_mask, 0.0);
+    // Update mouse state.
+    if (release_mouse & (1 << 0)) updateKeys(0 | mouse_wheel_mask, 0.0);
+    if (release_mouse & (1 << 1)) updateKeys(1 | mouse_wheel_mask, 0.0);
 
-    if (release_mouse & (1 << 2))
-        updateKeys(0 | mouse_movement_mask, 0.0);
-    if (release_mouse & (1 << 3))
-        updateKeys(1 | mouse_movement_mask, 0.0);
+    if (release_mouse & (1 << 2)) updateKeys(0 | mouse_movement_mask, 0.0);
+    if (release_mouse & (1 << 3)) updateKeys(1 | mouse_movement_mask, 0.0);
     release_mouse = 0;
 }
 
@@ -730,14 +731,14 @@ void Keybinding::handleEvent(const SDL_Event& event)
             || (event.key.keysym.sym >= SDLK_F1 && event.key.keysym.sym <= SDLK_F12)
             || (event.key.keysym.sym >= SDLK_F13 && event.key.keysym.sym <= SDLK_F24)
         )
-            updateKeys(event.key.keysym.sym | keyboard_mask, 1.0);
+            updateKeys(event.key.keysym.sym | keyboard_mask, 1.0f);
         break;
     case SDL_KEYUP:
         if (!SDL_IsTextInputActive()
             || (event.key.keysym.sym >= SDLK_F1 && event.key.keysym.sym <= SDLK_F12)
             || (event.key.keysym.sym >= SDLK_F13 && event.key.keysym.sym <= SDLK_F24)
         )
-            updateKeys(event.key.keysym.sym | keyboard_mask, 0.0);
+            updateKeys(event.key.keysym.sym | keyboard_mask, 0.0f);
         break;
     case SDL_MOUSEBUTTONDOWN:
         {
@@ -752,7 +753,7 @@ void Keybinding::handleEvent(const SDL_Event& event)
             default: break;
             }
             if (button != io::Pointer::Button::Unknown)
-                updateKeys(int(button) | pointer_mask, 1.0);
+                updateKeys(static_cast<int>(button) | pointer_mask, 1.0f);
         }
         break;
     case SDL_MOUSEBUTTONUP:
@@ -768,39 +769,46 @@ void Keybinding::handleEvent(const SDL_Event& event)
             default: break;
             }
             if (button != io::Pointer::Button::Unknown)
-                updateKeys(int(button) | pointer_mask, 0.0);
+                updateKeys(static_cast<int>(button) | pointer_mask, 0.0f);
         }
         break;
-    case SDL_MOUSEMOTION:{
-        int w, h;
-        SDL_GetWindowSize(SDL_GetWindowFromID(event.motion.windowID), &w, &h);
-        if (event.motion.xrel != 0)
+    case SDL_MOUSEMOTION:
         {
-            updateKeys(0 | mouse_movement_mask, float(event.motion.xrel) / float(w) * 500.0f);
-            release_mouse |= 1 << 2;
+            int w, h;
+            SDL_GetWindowSize(SDL_GetWindowFromID(event.motion.windowID), &w, &h);
+
+            if (event.motion.xrel != 0)
+            {
+                updateKeys(0 | mouse_movement_mask, float(event.motion.xrel) / float(w) * 500.0f);
+                release_mouse |= 1 << 2;
+            }
+
+            if (event.motion.yrel != 0)
+            {
+                updateKeys(1 | mouse_movement_mask, float(event.motion.yrel / float(h)) * 500.0f);
+                release_mouse |= 1 << 3;
+            }
         }
-        if (event.motion.yrel != 0)
-        {
-            updateKeys(1 | mouse_movement_mask, float(event.motion.yrel / float(h)) * 500.0f);
-            release_mouse |= 1 << 3;
-        }
-        }break;
+        break;
     case SDL_MOUSEWHEEL:
         if (event.wheel.x > 0)
         {
             updateKeys(0 | mouse_wheel_mask, 1.0);
             release_mouse |= 1 << 0;
         }
+
         if (event.wheel.x < 0)
         {
             updateKeys(0 | mouse_wheel_mask, -1.0);
             release_mouse |= 1 << 0;
         }
+
         if (event.wheel.y > 0)
         {
             updateKeys(1 | mouse_wheel_mask, 1.0);
             release_mouse |= 1 << 1;
         }
+
         if (event.wheel.y < 0)
         {
             updateKeys(1 | mouse_wheel_mask, -1.0);
@@ -809,11 +817,11 @@ void Keybinding::handleEvent(const SDL_Event& event)
         break;
     case SDL_FINGERDOWN:
         //event.tfinger.x, event.tfinger.x
-        updateKeys(int(io::Pointer::Button::Touch) | pointer_mask, 1.0);
+        updateKeys(static_cast<int>(io::Pointer::Button::Touch) | pointer_mask, 1.0f);
         break;
     case SDL_FINGERUP:
         //event.tfinger.x, event.tfinger.x
-        updateKeys(int(io::Pointer::Button::Touch) | pointer_mask, 0.0);
+        updateKeys(static_cast<int>(io::Pointer::Button::Touch) | pointer_mask, 0.0f);
         break;
 
     // To avoid competition between SDL_JOY... and SDL_CONTROLLER... events,
@@ -838,45 +846,42 @@ void Keybinding::handleEvent(const SDL_Event& event)
             SDL_Joystick* joystick = SDL_JoystickOpen(event.jdevice.which);
             if (joystick)
                 LOG(Info, "Found joystick:", SDL_JoystickName(joystick));
-            else
-                LOG(Warning, "Failed to open joystick...");
+            else LOG(Warning, "Failed to open joystick...");
         }
         break;
 
     case SDL_JOYDEVICEREMOVED:
-        for(int button=0; button<32; button++)
-            updateKeys(int(button) | int(event.jdevice.which) << 8 | joystick_button_mask, 0.0);
-        for(int axis=0; axis<32; axis++)
-        {
-            updateKeys(int(axis) | int(event.jdevice.which) << 8 | joystick_axis_mask, 0.0);
-        }
+        for (int button = 0; button < 32; button++)
+            updateKeys(button | static_cast<int>(event.jdevice.which) << 8 | joystick_button_mask, 0.0f);
+        for (int axis = 0; axis < 32; axis++)
+            updateKeys(axis | static_cast<int>(event.jdevice.which) << 8 | joystick_axis_mask, 0.0f);
+
         SDL_JoystickClose(SDL_JoystickFromInstanceID(event.jdevice.which));
         break;
     case SDL_CONTROLLERAXISMOTION:
-        updateKeys(int(event.caxis.axis) | int(event.caxis.which) << 8 | game_controller_axis_mask, float(event.caxis.value) / 32768.0f);
+        updateKeys(static_cast<int>(event.caxis.axis) | static_cast<int>(event.caxis.which) << 8 | game_controller_axis_mask, static_cast<float>(event.caxis.value) / 32768.0f);
         break;
     case SDL_CONTROLLERBUTTONDOWN:
-        updateKeys(int(event.cbutton.button) | int(event.cbutton.which) << 8 | game_controller_button_mask, 1.0);
+        updateKeys(static_cast<int>(event.cbutton.button) | static_cast<int>(event.cbutton.which) << 8 | game_controller_button_mask, 1.0f);
         break;
     case SDL_CONTROLLERBUTTONUP:
-        updateKeys(int(event.cbutton.button) | int(event.cbutton.which) << 8 | game_controller_button_mask, 0.0);
+        updateKeys(static_cast<int>(event.cbutton.button) | static_cast<int>(event.cbutton.which) << 8 | game_controller_button_mask, 0.0f);
         break;
     case SDL_CONTROLLERDEVICEADDED:
         {
             SDL_GameController* gc = SDL_GameControllerOpen(event.cdevice.which);
-            if (gc)
-                LOG(Info, "Found game controller:", SDL_GameControllerName(gc));
-            else
-                LOG(Warning, "Failed to open game controller...");
+            if (gc) LOG(Info, "Found game controller:", SDL_GameControllerName(gc));
+            else LOG(Warning, "Failed to open game controller...");
         }
         break;
     case SDL_CONTROLLERDEVICEREMOVED:
-        for(int button=0; button<SDL_CONTROLLER_BUTTON_MAX; button++)
-            updateKeys(int(button) | int(event.cdevice.which) << 8 | game_controller_button_mask, 0.0);
-        for(int axis=0; axis<SDL_CONTROLLER_AXIS_MAX; axis++)
+        for (int button = 0; button < SDL_CONTROLLER_BUTTON_MAX; button++)
+            updateKeys(button | static_cast<int>(event.cdevice.which) << 8 | game_controller_button_mask, 0.0f);
+        for (int axis = 0; axis < SDL_CONTROLLER_AXIS_MAX; axis++)
         {
-            updateKeys(int(axis) | int(event.cdevice.which) << 8 | game_controller_axis_mask, 0.0);
+            updateKeys(axis | static_cast<int>(event.cdevice.which) << 8 | game_controller_axis_mask, 0.0f);
         }
+
         SDL_GameControllerClose(SDL_GameControllerFromInstanceID(event.cdevice.which));
         break;
     case SDL_CONTROLLERDEVICEREMAPPED:
@@ -884,10 +889,9 @@ void Keybinding::handleEvent(const SDL_Event& event)
     case SDL_WINDOWEVENT:
         if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
         {
-            //Focus lost, release all keys.
-            for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
-                if (keybinding->bindings.size() > 0)
-                    keybinding->setValue(0.0f);
+            // Focus lost, release all keys.
+            for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
+                if (keybinding->bindings.size() > 0) keybinding->setValue(0.0f);
         }
         break;
     default:
@@ -906,9 +910,9 @@ void Keybinding::updateKeys(int key_number, float value)
         }
     }
 
-    for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
+    for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
     {
-        for(auto& bind : keybinding->bindings)
+        for (auto& bind : keybinding->bindings)
         {
             if (bind.key == key_number)
             {

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -374,6 +374,11 @@ void Keybinding::startUserRebind(Type bind_type, Interaction bind_interaction)
     rebinding_interaction = bind_interaction;
 }
 
+void Keybinding::cancelUserRebind()
+{
+    rebinding_key = nullptr;
+}
+
 bool Keybinding::isUserRebinding() const
 {
     return rebinding_key == this;

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -594,14 +594,12 @@ void Keybinding::addBinding(int key, bool inverted, Interaction interaction)
 
 void Keybinding::setValue(float new_value, int key_type, Interaction bind_interaction, float prev_bind_value)
 {
-    // Run existing per-key threshold/event logic first (delegate to 2-param overload).
+    // Run existing per-key threshold/event logic.
     setValue(new_value, key_type);
 
     // Per-interaction state update.
-    float threshold_value = fabs(new_value);
-    if (threshold_value < deadzone) threshold_value = 0.0f;
-    float prev_threshold = fabs(prev_bind_value);
-    if (prev_threshold < deadzone) prev_threshold = 0.0f;
+    float threshold_value = fabs(new_value) < deadzone ? 0.0f : new_value;
+    float prev_threshold = fabs(prev_bind_value) < deadzone ? 0.0f : prev_bind_value;
 
     switch (bind_interaction)
     {

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -7,6 +7,7 @@
 #include <unordered_set>
 #include <algorithm>
 #include <SDL_events.h>
+#include <SDL_timer.h>
 
 
 namespace sp {
@@ -18,6 +19,11 @@ Keybinding::Type Keybinding::rebinding_type;
 Keybinding::Interaction Keybinding::rebinding_interaction = Keybinding::Interaction::None;
 
 float Keybinding::deadzone = 0.05f;
+float Keybinding::discrete_step_size = 0.1f;
+float Keybinding::threshold = 0.5f;
+unsigned int Keybinding::repeat_delay = 500; // ms
+unsigned int Keybinding::repeat_interval = 40; // ms
+float Keybinding::sensitivity = 1.0f;
 
 Keybinding::Keybinding(const string& name)
 : name(name), label(name.substr(0, 1).upper() + name.substr(1).lower())
@@ -402,21 +408,24 @@ void Keybinding::loadKeybindings(const string& filename)
 
     auto json = parsed_json.value();
 
-    for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
+    const std::vector<std::pair<string, Interaction>> interaction_names = {
+        {"Continuous", Interaction::Continuous},
+        {"Discrete", Interaction::Discrete},
+        {"Repeating", Interaction::Repeating},
+        {"Axis0", Interaction::Axis0},
+        {"Axis1", Interaction::Axis1},
+    };
+
+    for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
     {
         const auto& entry = json[keybinding->name];
-        if (!entry.is_object())
-            continue;
+        if (!entry.is_object()) continue;
+
         if (entry["key"].is_string())
         {
             string key_str = entry["key"].get<std::string>();
             Interaction inter = Interaction::None;
-            const std::vector<std::pair<string, Interaction>> interaction_names = {
-                {"Sustained", Interaction::Sustained},
-                {"Stepped",   Interaction::Stepped},
-                {"Axis0",     Interaction::Axis0},
-                {"Axis1",     Interaction::Axis1},
-            };
+
             for (const auto& pair : interaction_names)
             {
                 string suffix = ":" + pair.first;
@@ -427,7 +436,9 @@ void Keybinding::loadKeybindings(const string& filename)
                     break;
                 }
             }
+
             keybinding->setKey(key_str);
+
             if (!keybinding->bindings.empty())
                 keybinding->bindings.back().interaction = inter;
         }
@@ -440,12 +451,6 @@ void Keybinding::loadKeybindings(const string& filename)
                 {
                     string key_str = key_entry.get<std::string>();
                     Interaction inter = Interaction::None;
-                    const std::vector<std::pair<string, Interaction>> interaction_names = {
-                        {"Sustained", Interaction::Sustained},
-                        {"Stepped",   Interaction::Stepped},
-                        {"Axis0",     Interaction::Axis0},
-                        {"Axis1",     Interaction::Axis1},
-                    };
                     for (const auto& pair : interaction_names)
                     {
                         string suffix = ":" + pair.first;
@@ -457,19 +462,27 @@ void Keybinding::loadKeybindings(const string& filename)
                         }
                     }
                     keybinding->addKey(key_str);
+
                     if (!keybinding->bindings.empty())
                         keybinding->bindings.back().interaction = inter;
                 }
             }
         }
-        else
-        {
-            keybinding->bindings.clear();
-        }
-        if (entry.contains("step") && entry["step"].is_number())
-            keybinding->step_size = entry["step"].get<float>();
-        if (entry.contains("sens") && entry["sens"].is_number())
-            keybinding->sensitivity = entry["sens"].get<float>();
+        else keybinding->bindings.clear();
+
+        // Get step size and threshold on discrete inputs.
+        if (entry.contains("discrete") && entry["discrete_step"].is_number())
+            keybinding->discrete_step_size = entry["discrete_step"].get<float>();
+        if (entry.contains("discrete") && entry["discrete_threshold"].is_number())
+            keybinding->threshold = entry["discrete_threshold"].get<float>();
+        // Get delay values on repeating inputs.
+        if (entry.contains("repeat") && entry["repeat_delay"].is_number())
+            keybinding->repeat_delay = entry["repeat_delay"].get<int>();
+        if (entry.contains("repeat") && entry["repeat_interval"].is_number())
+            keybinding->repeat_interval = entry["repeat_interval"].get<int>();
+        // Get sensitivity value on continuous inputs.
+        if (entry.contains("continuous") && entry["continuous_sensitivity"].is_number())
+            keybinding->sensitivity = entry["continuous_sensitivity"].get<float>();
     }
     LOG(Info, "Keybindings loaded from ", filename);
 }
@@ -490,10 +503,11 @@ void Keybinding::saveKeybindings(const string& filename)
                 string interaction_name;
                 switch (inter)
                 {
-                case Interaction::Sustained: interaction_name = "Sustained"; break;
-                case Interaction::Stepped:   interaction_name = "Stepped"; break;
-                case Interaction::Axis0:     interaction_name = "Axis0"; break;
-                case Interaction::Axis1:     interaction_name = "Axis1"; break;
+                case Interaction::Continuous: interaction_name = "Continuous"; break;
+                case Interaction::Discrete: interaction_name = "Discrete"; break;
+                case Interaction::Repeating: interaction_name = "Repeating"; break;
+                case Interaction::Axis0: interaction_name = "Axis0"; break;
+                case Interaction::Axis1: interaction_name = "Axis1"; break;
                 default: break;
                 }
                 if (!interaction_name.empty())
@@ -502,10 +516,19 @@ void Keybinding::saveKeybindings(const string& filename)
             keys.push_back(key_str.c_str());
         }
         data["key"] = keys;
-        if (keybinding->step_size != 0.1f)
-            data["step"] = keybinding->step_size;
+
+        // If interaction properties are defined, serialize them.
+        // TODO: Move defaults to consts.
+        if (keybinding->discrete_step_size != 0.1f)
+            data["discrete_step"] = keybinding->discrete_step_size;
+        if (keybinding->threshold != 0.5f)
+            data["discrete_threshold"] = keybinding->threshold;
+        if (keybinding->repeat_delay != 500)
+            data["repeat_delay"] = keybinding->repeat_delay;
+        if (keybinding->repeat_interval != 40)
+            data["repeat_interval"] = keybinding->repeat_interval;
         if (keybinding->sensitivity != 1.0f)
-            data["sens"] = keybinding->sensitivity;
+            data["continuous_sensitivity"] = keybinding->sensitivity;
         obj[keybinding->name] = data;
     }
 
@@ -574,26 +597,45 @@ void Keybinding::setValue(float new_value, int key_type, Interaction bind_intera
 
     // Per-interaction state update.
     float threshold_value = fabs(new_value);
-    if (threshold_value < deadzone)
-        threshold_value = 0.0f;
+    if (threshold_value < deadzone) threshold_value = 0.0f;
     float prev_threshold = fabs(prev_bind_value);
-    if (prev_threshold < deadzone)
-        prev_threshold = 0.0f;
+    if (prev_threshold < deadzone) prev_threshold = 0.0f;
 
     switch (bind_interaction)
     {
-    case Interaction::Sustained:
-        sustained_value = new_value;
+    case Interaction::Continuous:
+        continuous_value = new_value;
+        LOG(Debug, "Continuous: ", continuous_value);
         break;
-    case Interaction::Stepped:
-        if (prev_threshold < threshold && threshold_value >= threshold) stepped_down = true;
-        if (prev_threshold >= threshold && threshold_value < threshold) stepped_up = true;
+    case Interaction::Discrete:
+        if (prev_threshold < threshold && threshold_value >= threshold)
+            discrete_step_down = true;
+        if (prev_threshold >= threshold && threshold_value < threshold)
+            discrete_step_up = true;
+        LOG(Debug, "Discrete: down ", discrete_step_down ? "true" : "false", " up ", discrete_step_up ? "true" : "false");
+        break;
+    case Interaction::Repeating:
+        if (prev_threshold < threshold && threshold_value >= threshold)
+        {
+            repeat_ready = true;
+            repeat_hold_ticks = SDL_GetTicks();
+            repeat_started = false;
+        }
+
+        if (prev_threshold >= threshold && threshold_value < threshold)
+        {
+            repeat_hold_ticks = 0;
+            repeat_started = false;
+        }
+        LOG(Debug, "Repeating: ready ", repeat_ready ? "true" : "false", " up ", discrete_step_up ? "true" : "false", "\nhold ticks: ", repeat_hold_ticks, " started: ", repeat_started ? "true" : "false");
         break;
     case Interaction::Axis0:
         axis0_value = std::clamp(new_value, 0.0f, 1.0f);
+        LOG(Debug, "Axis0: ", axis0_value, " (", new_value, ")");
         break;
     case Interaction::Axis1:
         axis1_value = new_value;
+        LOG(Debug, "Axis1: ", axis1_value);
         break;
     default:
         break;
@@ -633,8 +675,9 @@ void Keybinding::postUpdate()
     else if (up_event)
         up_event = false;
 
-    stepped_down = false;
-    stepped_up = false;
+    discrete_step_down = false;
+    discrete_step_up = false;
+    repeat_ready = false;
 }
 
 static int release_mouse = 0;
@@ -643,7 +686,28 @@ void Keybinding::allPostUpdate()
 {
     for(Keybinding* keybinding = keybindings; keybinding; keybinding=keybinding->next)
         keybinding->postUpdate();
-    
+
+    unsigned int now = SDL_GetTicks();
+    for (Keybinding* keybinding = keybindings; keybinding; keybinding = keybinding->next)
+    {
+        if (keybinding->repeat_hold_ticks == 0)
+            continue;
+        bool has_repeating = false;
+        for (const auto& bind : keybinding->bindings)
+            if (bind.interaction == Interaction::Repeating) { has_repeating = true; break; }
+        if (!has_repeating)
+            continue;
+        const unsigned int wait = keybinding->repeat_started
+            ? repeat_interval
+            : repeat_delay + repeat_interval;
+        if (now - keybinding->repeat_hold_ticks >= wait)
+        {
+            keybinding->repeat_ready = true;
+            keybinding->repeat_hold_ticks = now;
+            keybinding->repeat_started = true;
+        }
+    }
+
     if (release_mouse & (1 << 0))
         updateKeys(0 | mouse_wheel_mask, 0.0);
     if (release_mouse & (1 << 1))

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -194,6 +194,12 @@ void Keybinding::clearKeys()
     bindings.clear();
 }
 
+Keybinding::Interaction Keybinding::getDefaultInteraction(Type type) const
+{
+    auto it = type_default_interactions.find(static_cast<int>(type));
+    return (it != type_default_interactions.end()) ? it->second : default_interaction;
+}
+
 void Keybinding::setDeadzone(float new_deadzone)
 {
     deadzone = new_deadzone;
@@ -617,7 +623,10 @@ void Keybinding::setValue(float new_value, int key_type, Interaction bind_intera
     float threshold_value = fabs(new_value) < deadzone ? 0.0f : new_value;
     float prev_threshold = fabs(prev_bind_value) < deadzone ? 0.0f : prev_bind_value;
 
-    switch (bind_interaction)
+    Interaction effective = getDefaultInteraction(static_cast<Type>((key_type & type_mask) >> 16));
+    if (bind_interaction != Interaction::None)
+        effective = bind_interaction;
+    switch (effective)
     {
     case Interaction::Continuous:
         continuous_value = new_value;

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -649,14 +649,12 @@ void Keybinding::setValue(float new_value, int key_type, Interaction bind_intera
     {
     case Interaction::Continuous:
         continuous_value = new_value;
-        LOG(Debug, "Continuous: ", continuous_value);
         break;
     case Interaction::Discrete:
         if (prev_threshold < threshold && threshold_value >= threshold)
             discrete_step_down = true;
         if (prev_threshold >= threshold && threshold_value < threshold)
             discrete_step_up = true;
-        LOG(Debug, "Discrete: down ", discrete_step_down ? "true" : "false", " up ", discrete_step_up ? "true" : "false");
         break;
     case Interaction::Repeating:
         if (prev_threshold < threshold && threshold_value >= threshold)
@@ -671,15 +669,12 @@ void Keybinding::setValue(float new_value, int key_type, Interaction bind_intera
             repeat_hold_ticks = 0;
             repeat_started = false;
         }
-        LOG(Debug, "Repeating: ready ", repeat_ready ? "true" : "false", " up ", discrete_step_up ? "true" : "false", "\nhold ticks: ", repeat_hold_ticks, " started: ", repeat_started ? "true" : "false");
         break;
     case Interaction::Axis0:
         axis0_value = std::clamp(new_value, 0.0f, 1.0f);
-        LOG(Debug, "Axis0: ", axis0_value, " (", new_value, ")");
         break;
     case Interaction::Axis1:
         axis1_value = new_value;
-        LOG(Debug, "Axis1: ", axis1_value);
         break;
     default:
         break;

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -698,8 +698,9 @@ void Keybinding::setValue(float new_value, int key_type)
         if (this->value >= threshold && threshold_value < threshold) up_event = true;
     }
 
-    // Set the keybind's value to the new value.
-    this->value = new_value;
+    // Store the absolute value so threshold comparisons on the next
+    // call work correctly for negative axis directions.
+    this->value = threshold_value;
 }
 
 void Keybinding::postUpdate()

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -408,6 +408,8 @@ void Keybinding::cancelUserRebind()
     rebinding_key = nullptr;
     rebinding_cancel_key = nullptr;
     rebinding_preview_mode = false;
+    rebinding_preview_target = nullptr;
+    rebinding_preview_key = 0;
 }
 
 void Keybinding::setUserRebindCancelKey(Keybinding* cancel_key)

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -515,17 +515,17 @@ void Keybinding::loadKeybindings(const string& filename)
         else keybinding->bindings.clear();
 
         // Get step size and threshold on discrete inputs.
-        if (entry.contains("discrete") && entry["discrete_step"].is_number())
+        if (entry.contains("discrete_step") && entry["discrete_step"].is_number())
             keybinding->discrete_step_size = entry["discrete_step"].get<float>();
-        if (entry.contains("discrete") && entry["discrete_threshold"].is_number())
+        if (entry.contains("discrete_threshold") && entry["discrete_threshold"].is_number())
             keybinding->threshold = entry["discrete_threshold"].get<float>();
         // Get delay values on repeating inputs.
-        if (entry.contains("repeat") && entry["repeat_delay"].is_number())
+        if (entry.contains("repeat_delay") && entry["repeat_delay"].is_number())
             keybinding->repeat_delay = entry["repeat_delay"].get<int>();
-        if (entry.contains("repeat") && entry["repeat_interval"].is_number())
+        if (entry.contains("repeat_interval") && entry["repeat_interval"].is_number())
             keybinding->repeat_interval = entry["repeat_interval"].get<int>();
         // Get sensitivity value on continuous inputs.
-        if (entry.contains("continuous") && entry["continuous_sensitivity"].is_number())
+        if (entry.contains("continuous_sensitivity") && entry["continuous_sensitivity"].is_number())
             keybinding->sensitivity = entry["continuous_sensitivity"].get<float>();
     }
     LOG(Info, "Keybindings loaded from ", filename);

--- a/src/io/keybinding.cpp
+++ b/src/io/keybinding.cpp
@@ -27,11 +27,6 @@ bool Keybinding::rebinding_preview_inverted = false;
 Keybinding::Interaction Keybinding::rebinding_preview_interaction = Keybinding::Interaction::None;
 
 float Keybinding::deadzone = 0.05f;
-float Keybinding::discrete_step_size = 0.1f;
-float Keybinding::threshold = 0.5f;
-unsigned int Keybinding::repeat_delay = 500; // ms
-unsigned int Keybinding::repeat_interval = 40; // ms
-float Keybinding::sensitivity = 1.0f;
 
 Keybinding::Keybinding(const string& name)
 : name(name), label(name.substr(0, 1).upper() + name.substr(1).lower())

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -138,7 +138,6 @@ public:
     float getContinuousValue() const { return continuous_value * sensitivity; }
     // Discrete: single step applied once per press.
     bool isDiscreteStepDown() const { return discrete_step_down; }
-    bool getDiscreteStepDown() const { return discrete_step_down; }
     bool isDiscreteStepUp() const { return discrete_step_up; }
     // Returns discrete_step_size when a Discrete bind fired this frame, 0 otherwise.
     float getDiscreteValue() const { return discrete_step_down ? discrete_step_size : 0.0f; }

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -170,6 +170,25 @@ public:
     static void setUserRebindCancelKey(Keybinding* cancel_key);
     bool isUserRebinding() const;
 
+    // Preview-mode rebind: captures key without committing it to bindings.
+    void startUserRebindPreview(Type bind_type = Type::Default, Interaction bind_interaction = Interaction::None);
+    // Returns true if a key was captured in preview mode for this keybinding.
+    bool hasPendingRebind() const;
+    // Returns a human-readable name of the previewed key. Empty string if no pending.
+    string getPendingRebindKeyName() const;
+    // Returns the key type of the previewed key. None if no pending.
+    Type getPendingRebindKeyType() const;
+    // Returns the raw key number of the pending rebind. 0 if no pending.
+    int getPendingRebindRawKey() const;
+    // Returns the raw key number of the binding at the given index. 0 if out of range.
+    int getRawKeyNumber(int index) const;
+    // Updates the interaction stored in the pending rebind.
+    void setPendingRebindInteraction(Interaction interaction);
+    // Adds the pending key to this binding's list and clears the pending state.
+    void commitPendingRebind();
+    // Discards the pending key without adding it.
+    void discardPendingRebind();
+
     static int joystickCount();
     static int gamepadCount();
 
@@ -243,6 +262,14 @@ private:
     static Keybinding* rebinding_cancel_key;
     static Type rebinding_type;
     static Interaction rebinding_interaction;
+
+    static bool rebinding_preview_mode;
+    static Keybinding* rebinding_preview_target;
+    static int rebinding_preview_key;
+    static bool rebinding_preview_inverted;
+    static Interaction rebinding_preview_interaction;
+
+    static string keyNameForRaw(int key, bool inverted);
     
     static constexpr int type_mask = 0xfff << 16;
     static constexpr int keyboard_mask = static_cast<int>(Type::Keyboard) << 16;

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -165,6 +165,9 @@ public:
     void startUserRebind(Type bind_type = Type::Default, Interaction bind_interaction = Interaction::None);
     // Cancel any in-progress user rebind, regardless of which keybinding started it.
     static void cancelUserRebind();
+    // Set a keybinding whose bound keys cancel (rather than capture) an active
+    // rebind when pressed. Pass nullptr to clear. Only checked during a rebind.
+    static void setUserRebindCancelKey(Keybinding* cancel_key);
     bool isUserRebinding() const;
 
     static int joystickCount();
@@ -237,6 +240,7 @@ private:
     static Keybinding* keybindings;
     Keybinding* next=nullptr;
     static Keybinding* rebinding_key;
+    static Keybinding* rebinding_cancel_key;
     static Type rebinding_type;
     static Interaction rebinding_interaction;
     

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -107,6 +107,9 @@ public:
     void addKey(const string& key, bool inverted=false);
     void removeKey(int index);
     void clearKeys();
+    // Returns true if the binding at index has its axis inverted.
+    bool getKeyInverted(int index) const;
+    void setKeyInverted(int index, bool inverted);
 
     static void setDeadzone(float deadzone);
 
@@ -192,6 +195,9 @@ public:
     int getRawKeyNumber(int index) const;
     // Updates the interaction stored in the pending rebind.
     void setPendingRebindInteraction(Interaction interaction);
+    // Returns/sets whether the pending rebind axis is inverted.
+    bool getPendingRebindInverted() const;
+    void setPendingRebindInverted(bool inverted);
     // Adds the pending key to this binding's list and clears the pending state.
     void commitPendingRebind();
     // Discards the pending key without adding it.

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -15,6 +15,9 @@ namespace io {
 class Keybinding : sp::NonCopyable
 {
 public:
+    // Key type, indicative of the input (device) method.
+    // What is being used to trigger this bind?
+    // User input upon binding should define the type.
     enum class Type {
         None = 0,
         Keyboard = (1 << 0),
@@ -34,7 +37,41 @@ public:
         Default = Keyboard | Virtual | Joystick | Controller | Mouse,
     };
 
-    //Create a keybinding, and optionally set the default key(s). See setKey for documentation on key naming.
+    // Key interaction, indicative of the output (control) method.
+    // How does this bind trigger its bound control?
+    // The control should define its interaction, not the user.
+    enum class Interaction {
+        // No defined interaction. Equivalent to Sustained but should
+        // emit a warning.
+        None = 0,
+
+        // Default. Binary actions that fire continuously at a steady
+        // rate each update while onDown/non-zero and stop on onUp;
+        // momentary controls, digital steering.
+        // EE examples: Missile tube firing controls.
+        Sustained = (1 << 0),
+
+        // Binary actions that fire once onDown/past a threshold
+        // regardless of time held; encoders, toggle switches,
+        // controls with detent-only values.
+        // EE examples: Most buttons, warp factor slider, scan sliders.
+        Stepped = (1 << 1),
+
+        // Actions with variable values between 0 and 1, typically
+        // with deadzones at 0 and 1. Linear triggers and
+        // potentiometers, pressure-sensitive buttons, unidirectional
+        // throttles.
+        // EE examples: Combat manevuer forward boost, jump distance slider.
+        Axis0 = (1 << 3),
+
+        // Actions with variable values between -1 and 1, typically
+        // with a deadzone at 0. Steering axes, bidirectional
+        // throttles.
+        // EE examples: Helms rotation, impulse throttle.
+        Axis1 = (1 << 4)
+    };
+
+    // Create a keybinding, and optionally set the default key(s). See setKey for documentation on key naming.
     Keybinding(const string& name);
     Keybinding(const string& name, const string& default_key);
     Keybinding(const string& name, const std::initializer_list<const string>& default_keys);
@@ -43,6 +80,9 @@ public:
     const string& getName() const { return name; }
     const string& getLabel() const { return label; }
     const string& getCategory() const { return category; }
+    // Get the Keybinding::Interaction of this bind. Returns None if the index
+    // is out of range.
+    Interaction getInteraction(int index) const;
     void setLabel(const string& label) { this->label = label; }
     void setLabel(const string& category, const string& label) { this->category = category; this->label = label; }
 
@@ -65,23 +105,49 @@ public:
 
     static void setDeadzone(float deadzone);
 
-    // Get the name of the key in the same format as used for setKey and friends. Returns empty string if the index as no set key.
+    // Get the name of the key in the same format as used for setKey and friends.
+    // Returns empty string if the index as no set key.
     string getKey(int index) const;
+    // Get the Keybinding::Type of this bind. Returns None if the index is out
+    // of range.
     Type getKeyType(int index) const;
-    // Get a human readable name of the key for display purposes.
+    // Get a human-readable name of the key for display purposes.
     string getHumanReadableKeyName(int index) const;
 
     // Returns true if there is anything bound to this keybinding.
     bool isBound() const;
 
-    bool get() const; //True when this key is currently being pressed.
-    bool getDown() const; //True for 1 update cycle when the key is pressed.
-    bool getUp() const; //True for 1 update cycle when the key is released.
-    float getValue() const; //Returns a value in the range -1 to 1 for this keybinding. On keyboard keys this is always 0 or 1, but for joysticks this can be anywhere in the range -1.0 to 1.0
+    // Returns true when this key is currently being pressed.
+    bool get() const;
+    // Returns true for 1 update cycle when the key is pressed.
+    bool getDown() const;
+    // Returns true for 1 update cycle when the key is released.
+    bool getUp() const;
+    // Returns a value in the range -1 to 1 for this keybinding. On keyboard keys this is always 0 or 1, but for joysticks this can be anywhere in the range -1.0 to 1.0
+    float getValue() const;
+
+    void setSupportedInteractions(Interaction i) { supported_interactions = i; }
+    Interaction getSupportedInteractions() const { return supported_interactions; }
+
+    // Per-interaction aggregate query methods.
+    // Sustained: raw value multiplied by sensitivity.
+    float getSustainedValue() const { return sustained_value * sensitivity; }
+    bool getSteppedDown() const { return stepped_down; }
+    bool getSteppedUp() const { return stepped_up; }
+    // Returns step_size when a Stepped bind fired this frame, 0 otherwise.
+    float getSteppedValue() const { return stepped_down ? step_size : 0.0f; }
+    float getAxis0Value() const { return axis0_value; }
+    float getAxis1Value() const { return axis1_value; }
+
+    // Per-keybinding Stepped / Sustained configuration.
+    float getStepSize() const { return step_size; }
+    void setStepSize(float v) { step_size = v; }
+    float getSensitivity() const { return sensitivity; }
+    void setSensitivity(float v) { sensitivity = v; }
 
     // Start a binding process from the user. The next button pressed by the user will be bound to this key.
     // Note that this will add on top of the already existing binds, so clearKeys() need to be called if you want to bind a single key.
-    void startUserRebind(Type bind_type=Type::Default);
+    void startUserRebind(Type bind_type = Type::Default, Interaction bind_interaction = Interaction::None);
     bool isUserRebinding() const;
 
     static int joystickCount();
@@ -108,18 +174,29 @@ private:
     {
         int key;
         bool inverted;
+        Interaction interaction = Interaction::None;
+        float last_value = 0.0f;
     };
     std::vector<Binding> bindings;
+    Interaction supported_interactions = Interaction::None;
 
     static float deadzone;
     static constexpr float threshold = 0.5f;
     float value;
     bool down_event;
     bool up_event;
+    float sustained_value = 0.0f;
+    bool stepped_down = false;
+    bool stepped_up = false;
+    float axis0_value = 0.0f;
+    float axis1_value = 0.0f;
+    float step_size = 0.1f;
+    float sensitivity = 1.0f;
 
     string getKeyInternal(int index) const;
-    void addBinding(int key, bool inverted);
+    void addBinding(int key, bool inverted, Interaction interaction = Interaction::None);
 
+    void setValue(float new_value, int key_type, Interaction bind_interaction, float prev_bind_value);
     void setValue(float new_value, int key_type = 0);
     void postUpdate();
     
@@ -132,6 +209,7 @@ private:
     Keybinding* next=nullptr;
     static Keybinding* rebinding_key;
     static Type rebinding_type;
+    static Interaction rebinding_interaction;
     
     static constexpr int type_mask = 0xfff << 16;
     static constexpr int keyboard_mask = static_cast<int>(Type::Keyboard) << 16;
@@ -149,6 +227,9 @@ private:
 
 bool operator&(const Keybinding::Type a, const Keybinding::Type b);
 Keybinding::Type operator|(const Keybinding::Type a, const Keybinding::Type b);
+
+bool operator&(Keybinding::Interaction a, Keybinding::Interaction b);
+Keybinding::Interaction operator|(Keybinding::Interaction a, Keybinding::Interaction b);
 
 }//namespace io
 }//namespace sp

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -163,6 +163,8 @@ public:
     // user will be bound to this key. This will add on top of the existing
     // binds, so clearKeys() must be called in order to bind only one input.
     void startUserRebind(Type bind_type = Type::Default, Interaction bind_interaction = Interaction::None);
+    // Cancel any in-progress user rebind, regardless of which keybinding started it.
+    static void cancelUserRebind();
     bool isUserRebinding() const;
 
     static int joystickCount();

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -3,6 +3,7 @@
 #include <stringImproved.h>
 #include <nonCopyable.h>
 #include <io/pointer.h>
+#include <unordered_map>
 
 //Forward declare the event structure, so we can pass it by reference to the keybindings, without exposing all SDL stuff.
 union SDL_Event;
@@ -158,6 +159,13 @@ public:
     void setRepeatInterval(unsigned int v) { repeat_interval = v; }
     float getContinuousSensitivity() const { return sensitivity; }
     void setContinuousSensitivity(float v) { sensitivity = v; }
+    // Default interaction used when a binding has Interaction::None.
+    // Allows controls to define sensible behavior for undecorated key presses.
+    // Per-type overrides take priority over the global default.
+    Interaction getDefaultInteraction() const { return default_interaction; }
+    void setDefaultInteraction(Interaction i) { default_interaction = i; }
+    Interaction getDefaultInteraction(Type type) const;
+    void setDefaultInteraction(Type type, Interaction i) { type_default_interactions[static_cast<int>(type)] = i; }
 
     // Start a binding process from the user. The next button pressed by the
     // user will be bound to this key. This will add on top of the existing
@@ -218,6 +226,8 @@ private:
     };
     std::vector<Binding> bindings;
     Interaction supported_interactions = Interaction::None;
+    Interaction default_interaction = Interaction::None;
+    std::unordered_map<int, Interaction> type_default_interactions;
 
     // Deadzone tolerance.
     static float deadzone;

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -152,9 +152,9 @@ public:
     // Per-keybinding configuration.
     float getDiscreteStepSize() const { return discrete_step_size; }
     void setDiscreteStepSize(float v) { discrete_step_size = v; }
-    float getRepeatDelay() const { return repeat_delay; }
+    unsigned int getRepeatDelay() const { return repeat_delay; }
     void setRepeatDelay(unsigned int v) { repeat_delay = v; }
-    float getRepeatInterval() const { return repeat_interval; }
+    unsigned int getRepeatInterval() const { return repeat_interval; }
     void setRepeatInterval(unsigned int v) { repeat_interval = v; }
     float getContinuousSensitivity() const { return sensitivity; }
     void setContinuousSensitivity(float v) { sensitivity = v; }

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -17,7 +17,7 @@ class Keybinding : sp::NonCopyable
 public:
     // Key type, indicative of the input (device) method.
     // What is being used to trigger this bind?
-    // User input upon binding should define the type.
+    // The user's input defines the input type upon binding.
     enum class Type {
         None = 0,
         Keyboard = (1 << 0),
@@ -37,36 +37,40 @@ public:
         Default = Keyboard | Virtual | Joystick | Controller | Mouse,
     };
 
-    // Key interaction, indicative of the output (control) method.
+    // Key interaction types, indicative of the output (control) method.
     // How does this bind trigger its bound control?
-    // The control should define its interaction, not the user.
+    // The control should define available interactions, not the user.
     enum class Interaction {
-        // No defined interaction. Equivalent to Sustained but should
-        // emit a warning.
+        // No defined interaction. Equivalent to Continuous but should emit a
+        // warning.
         None = 0,
 
-        // Default. Binary actions that fire continuously at a steady
-        // rate each update while onDown/non-zero and stop on onUp;
-        // momentary controls, digital steering.
+        // Default. Binary actions that fire continuously at a steady rate each
+        // update while onDown/non-zero and stop on onUp; momentary controls,
+        // digital steering.
         // EE examples: Missile tube firing controls.
-        Sustained = (1 << 0),
+        Continuous = (1 << 0),
 
-        // Binary actions that fire once onDown/past a threshold
-        // regardless of time held; encoders, toggle switches,
-        // controls with detent-only values.
+        // Binary actions that fire once onDown/past a threshold regardless of
+        // time held; encoders, toggle switches, controls with detent-only
+        // values.
         // EE examples: Most buttons, warp factor slider, scan sliders.
-        Stepped = (1 << 1),
+        Discrete = (1 << 1),
 
-        // Actions with variable values between 0 and 1, typically
-        // with deadzones at 0 and 1. Linear triggers and
-        // potentiometers, pressure-sensitive buttons, unidirectional
-        // throttles.
+        // Binary actions that fire once onDown/past a threshold, waits for a
+        // period, and then fires the action repeatedly on an interval.
+        // Alternative to both Discrete and Continuous interactions, for
+        // backward compatibility with pre-legacy SFML behaviors.
+        Repeating = (1 << 2),
+
+        // Actions with variable values between 0 and 1, typically with
+        // deadzones at 0 and 1. Linear triggers and potentiometers,
+        // pressure-sensitive buttons, unidirectional throttles.
         // EE examples: Combat manevuer forward boost, jump distance slider.
         Axis0 = (1 << 3),
 
-        // Actions with variable values between -1 and 1, typically
-        // with a deadzone at 0. Steering axes, bidirectional
-        // throttles.
+        // Actions with variable values between -1 and 1, typically with a
+        // deadzone at 0. Steering axes, bidirectional throttles.
         // EE examples: Helms rotation, impulse throttle.
         Axis1 = (1 << 4)
     };
@@ -130,23 +134,35 @@ public:
     Interaction getSupportedInteractions() const { return supported_interactions; }
 
     // Per-interaction aggregate query methods.
-    // Sustained: raw value multiplied by sensitivity.
-    float getSustainedValue() const { return sustained_value * sensitivity; }
-    bool getSteppedDown() const { return stepped_down; }
-    bool getSteppedUp() const { return stepped_up; }
-    // Returns step_size when a Stepped bind fired this frame, 0 otherwise.
-    float getSteppedValue() const { return stepped_down ? step_size : 0.0f; }
+    // Continuous: sustained value sent every frame and multiplied by sensitivity.
+    float getContinuousValue() const { return continuous_value * sensitivity; }
+    // Discrete: single step applied once per press.
+    bool isDiscreteStepDown() const { return discrete_step_down; }
+    bool getDiscreteStepDown() const { return discrete_step_down; }
+    bool isDiscreteStepUp() const { return discrete_step_up; }
+    // Returns discrete_step_size when a Discrete bind fired this frame, 0 otherwise.
+    float getDiscreteValue() const { return discrete_step_down ? discrete_step_size : 0.0f; }
+    // Repeating: single discrete step applied once, then repeatedly on an
+    // interval after a delay.
+    bool isRepeatReady() const { return repeat_ready; }
+    // Axis0: axis value from 0.0 to 1.0, dead at extremities.
     float getAxis0Value() const { return axis0_value; }
+    // Axis1: axis value from -1.0 to 1.0, dead at 0.0.
     float getAxis1Value() const { return axis1_value; }
 
-    // Per-keybinding Stepped / Sustained configuration.
-    float getStepSize() const { return step_size; }
-    void setStepSize(float v) { step_size = v; }
-    float getSensitivity() const { return sensitivity; }
-    void setSensitivity(float v) { sensitivity = v; }
+    // Per-keybinding configuration.
+    float getDiscreteStepSize() const { return discrete_step_size; }
+    void setDiscreteStepSize(float v) { discrete_step_size = v; }
+    float getRepeatDelay() const { return repeat_delay; }
+    void setRepeatDelay(unsigned int v) { repeat_delay = v; }
+    float getRepeatInterval() const { return repeat_interval; }
+    void setRepeatInterval(unsigned int v) { repeat_interval = v; }
+    float getContinuousSensitivity() const { return sensitivity; }
+    void setContinuousSensitivity(float v) { sensitivity = v; }
 
-    // Start a binding process from the user. The next button pressed by the user will be bound to this key.
-    // Note that this will add on top of the already existing binds, so clearKeys() need to be called if you want to bind a single key.
+    // Start a binding process from the user. The next button pressed by the
+    // user will be bound to this key. This will add on top of the existing
+    // binds, so clearKeys() must be called in order to bind only one input.
     void startUserRebind(Type bind_type = Type::Default, Interaction bind_interaction = Interaction::None);
     bool isUserRebinding() const;
 
@@ -180,18 +196,30 @@ private:
     std::vector<Binding> bindings;
     Interaction supported_interactions = Interaction::None;
 
+    // Deadzone tolerance.
     static float deadzone;
-    static constexpr float threshold = 0.5f;
+    // Discrete input step size
+    static float discrete_step_size;
+    // Discrete input +/- threshold.
+    static float threshold;
+    // Repeating input delay after first event, in milliseconds.
+    static unsigned int repeat_delay;
+    // Repeating input interval after second event, in milliseconds.
+    static unsigned int repeat_interval;
+    // Continuous input sensitivity factor.
+    static float sensitivity;
+
     float value;
     bool down_event;
     bool up_event;
-    float sustained_value = 0.0f;
-    bool stepped_down = false;
-    bool stepped_up = false;
+    float continuous_value = 0.0f;
+    bool discrete_step_down = false;
+    bool discrete_step_up = false;
+    bool repeat_ready = false;
+    unsigned int repeat_hold_ticks = 0; // SDL ticks at initial press (0 = not held)
+    bool repeat_started = false; // true after first repeat has fired
     float axis0_value = 0.0f;
     float axis1_value = 0.0f;
-    float step_size = 0.1f;
-    float sensitivity = 1.0f;
 
     string getKeyInternal(int index) const;
     void addBinding(int key, bool inverted, Interaction interaction = Interaction::None);

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -88,6 +88,9 @@ public:
     // Get the Keybinding::Interaction of this bind. Returns None if the index
     // is out of range.
     Interaction getInteraction(int index) const;
+    // Set the Keybinding::Interaction of this bind. No-op if the index is out
+    // of range.
+    void setInteraction(int index, Interaction i);
     void setLabel(const string& label) { this->label = label; }
     void setLabel(const string& category, const string& label) { this->category = category; this->label = label; }
 

--- a/src/io/keybinding.h
+++ b/src/io/keybinding.h
@@ -241,15 +241,15 @@ private:
     // Deadzone tolerance.
     static float deadzone;
     // Discrete input step size
-    static float discrete_step_size;
+    float discrete_step_size = 0.1f;
     // Discrete input +/- threshold.
-    static float threshold;
+    float threshold = 0.5f;
     // Repeating input delay after first event, in milliseconds.
-    static unsigned int repeat_delay;
+    unsigned int repeat_delay = 500;
     // Repeating input interval after second event, in milliseconds.
-    static unsigned int repeat_interval;
+    unsigned int repeat_interval = 40;
     // Continuous input sensitivity factor.
-    static float sensitivity;
+    float sensitivity = 1.0f;
 
     float value;
     bool down_event;


### PR DESCRIPTION
SP's input system passes input values down state, up state, and normalized values to a game, and the game defines how each hotkey interacts with game systems.

Before the move to SDL, SFML limitations indirectly delineated different interaction types (keyboards sent OS-defined repeating down events if enabled, buttons sent high-low values, axes sent variable values). After the move to SDL's more polished input system, keyboard repeat interactions were lost. However, players relied on this behavior.

SDL additionally differentiates between different controller and axis types in ways SFML did not. SDL can interpret and send values from both monodirectional gamecontroller axes (triggers, pressure-sensitive buttons) that normalize from 0 to 1 and rest at 0; bidirectional joysticks that normalize from -1 to 1 and rest at 0; and digital axes (gamepads, hats) that normalize across -1 to 1 like bidirectional axes but behave like buttons.

Redefine input to use these SDL features and allow hotkeys to define supported and default interactions. This allows hotkeys to decide whether to treat inputs as:

- discrete interactions, as high-low button presses that send one action upon hitting their threshold
- continuous interactions, which act based on their value every tick
- repeating interactions, which simulate SFML's passing of OS-defined keyboard repeating behavior but allow the game to customize timings
- monodirectional axis interactions (`axis0`), which rest at 0 as a minimum and don't return negative values; this represents triggers with an 0-1 axis, or half of a joystick's bidirectional axis
- bidirectional axis interactions (`axis1`, which rest at 0 as a center value between min (-1) and max (1) values

This PR provides an API for the game to use to define which interaction types a hotkey supports. For example, a hotkey representing an on-screen toggle button would support only discrete interactions, while combat manuevers would support continuous interactions (for accumulation via digital input), bidirectional axes (for strafe), and monodirectional axes (for boost).

This PR also provides a function to define which interaction type is its default, if multiple types are supported. This allows the game to simplify hotkey binding by defaulting to assigning inputs to the defined default type, while still providing flexibility for more advanced configurations that support unusual hardware, such as keyboard-emulating encoders; HOTAS/HOSAS monodirectional throttles, multi-axis sticks, digital and analog hats, pots/sliders, and encoder/pot knobs and dials; and MIDI-to-HID sliders, knobs, and pressure-sensitive buttons.

THIS SHOULD NOT CHANGE, AND DOES NOT REMOVE, EXISTING BEHAVIORS. `getDown`, `getUp`, and `getValue` remain in place. All hotkeys continue to work in EE with this PR as they would without it.

## Example implementations in EE

While initializing the `Keys` class, define a simple button-style hotkey as Discrete-only by invoking its `setSupportedInteractions(sp::io::Keybinding::Interaction::Discrete)`:

```diff
 void Keys::init()
 {
     pause.setLabel(tr("hotkey_menu", "General"), tr("hotkey_General", "Pause game"));
+    pause.setSupportedInteractions(sp::io::Keybinding::Interaction::Discrete);

     ...
```

`setSupportedInteractions` takes a mask, allowing multiple interactions to be supported at once:

```
    zoom_in.setSupportedInteractions(
        sp::io::Keybinding::Interaction::Discrete |
        sp::io::Keybinding::Interaction::Repeating |
        sp::io::Keybinding::Interaction::Continuous |
        sp::io::Keybinding::Interaction::Axis0 |
        sp::io::Keybinding::Interaction::Axis1
    );
```

When a hotkey supports multiple interactions, define one as the default. If no default is explicitly defined, Continuous (representing the existing behavior without this PR) is assumed.

```
    zoom_in.setDefaultInteraction(sp::io::Keybinding::Interaction::Repeating);
```

If a different interaction type should be the default for a different input type, optionally define that to override the global default interaction:

```
    zoom_in.setDefaultInteraction(sp::io::Keybinding::Type::JoystickAxis, sp::io::Keybinding::Interaction::Axis1);
    zoom_in.setDefaultInteraction(sp::io::Keybinding::Type::ControllerAxis, sp::io::Keybinding::Interaction::Axis1);
```

Helms slider behaviors, the most commonly debated action regarding the SFML/SDL changes in interactions:

```
    helms_increase_impulse.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Increase impulse"));
    helms_increase_impulse.setSupportedInteractions(
        sp::io::Keybinding::Interaction::Discrete |
        sp::io::Keybinding::Interaction::Repeating |
        sp::io::Keybinding::Interaction::Continuous |
        sp::io::Keybinding::Interaction::Axis0 |
        sp::io::Keybinding::Interaction::Axis1
    );
    helms_increase_impulse.setDefaultInteraction(sp::io::Keybinding::Interaction::Repeating);
    helms_increase_impulse.setDefaultInteraction(sp::io::Keybinding::Type::JoystickAxis, sp::io::Keybinding::Interaction::Axis1);
    helms_increase_impulse.setDefaultInteraction(sp::io::Keybinding::Type::ControllerAxis, sp::io::Keybinding::Interaction::Axis1);
```

The above:

- Sets the helms increase keybind to repeating SFML-like behavior by default
- Allows binding the input as discrete (for encoders), repeating (for keyboards), continuous (for button/digital axis), axis0 (gamepad left/right trigger), and axis1 (joystick)
- Changes the default to axis1 for joysticks and game controllers

Where the hotkey action is implemented in impulse controls, use the hotkey's new functions for receiving values for each supported interaction type.

- `isDiscreteStepDown()` returns true if the hotkey is activated
- `isRepeatReady()` returns true if the hotkey is activated and the timeout hasn't started, the timeout (i.e. 500ms) has elapsed, or the delay period (i.e. every 5ms after the timeout) has elapsed
- `getContinuousValue()` returns 1.0 if the hotkey is activated
- `getAxis0Value()` and `getAxis1Value()` return a normalized value

```
void GuiImpulseControls::onUpdate()
{
    ...
    float change = keys.helms_increase_impulse.getContinuousValue() - keys.helms_decrease_impulse.getContinuousValue()
        - keys.helms_increase_impulse.getAxis0Value() + keys.helms_decrease_impulse.getAxis0Value()
        - keys.helms_increase_impulse.getAxis1Value() + keys.helms_decrease_impulse.getAxis1Value();
    if (change != 0.0f)
        my_player_info->commandImpulse(std::clamp(slider->getValue() + change * 0.01f, -1.0f, 1.0f));
    if (keys.helms_increase_impulse.isDiscreteStepDown() || keys.helms_increase_impulse.isRepeatReady())
        my_player_info->commandImpulse(std::min(1.0f, slider->getValue() + 0.1f));
```